### PR TITLE
Refactor validation and utility functions

### DIFF
--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -429,7 +429,7 @@ class TestElement(unittest.TestCase):
         spacing = 1
         element = Element(shape, z, spacing=spacing)
         with self.assertRaises(TypeError):
-            element.validate_field_geometry("not a field")
+            element.validate_field("not a field")
         field = Field(torch.ones(3, *shape), wavelength=700e-9, spacing=spacing, z=2)
         with self.assertRaises(ValueError):
-            element.validate_field_geometry(field)
+            element.validate_field(field)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -142,9 +142,9 @@ class TestMeshgrid2D(unittest.TestCase):
 class TestInitializetensor(unittest.TestCase):
     def test_initialize_tensor(self):
         with self.assertRaises(ValueError):
-            initialize_tensor("name", 1.0, (), is_complex=True, is_integer=True)
+            initialize_tensor("name", 1.0, is_scalar=True, is_complex=True, is_integer=True)
         with self.assertRaises(ValueError):
-            initialize_tensor("name", 1.1, (), is_complex=False, is_integer=True)
+            initialize_tensor("name", 1.1, is_scalar=True, is_complex=False, is_integer=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -139,13 +139,5 @@ class TestMeshgrid2D(unittest.TestCase):
         self.assertTrue(torch.allclose(actual_y, expected_y))
 
 
-class TestInitializetensor(unittest.TestCase):
-    def test_initialize_tensor(self):
-        with self.assertRaises(ValueError):
-            initialize_tensor("name", 1.0, is_scalar=True, is_complex=True, is_integer=True)
-        with self.assertRaises(ValueError):
-            initialize_tensor("name", 1.1, is_scalar=True, is_complex=False, is_integer=True)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optics_module.py
+++ b/tests/test_optics_module.py
@@ -56,10 +56,10 @@ class TestOpticsModule(unittest.TestCase):
         module.register_optics_property("prop1", value, is_complex=True)
         self.assertTrue(module.prop1.is_complex())
 
-    def test_validate_positive(self):
+    def test_is_positive(self):
         module = OpticsModule()
         value = torch.tensor([1.0, 2.0, 3.0])
-        module.register_optics_property("prop1", value, validate_positive=True)
+        module.register_optics_property("prop1", value, is_positive=True)
         invalid_value = torch.tensor([-1.0, 2.0, 3.0])
         with self.assertRaises(ValueError):
             module.set_optics_property("prop1", invalid_value)

--- a/tests/test_optics_module.py
+++ b/tests/test_optics_module.py
@@ -64,13 +64,6 @@ class TestOpticsModule(unittest.TestCase):
         with self.assertRaises(ValueError):
             module.set_optics_property("prop1", invalid_value)
 
-    def test_fill_value(self):
-        module = OpticsModule()
-        value = 2.0
-        module.register_optics_property("prop1", value, shape=(3,), fill_value=True)
-        expected_tensor = torch.tensor([2.0, 2.0, 2.0], dtype=torch.double)
-        self.assertTrue(torch.equal(module.prop1, expected_tensor))
-
     def test_register_property_before_init(self):
         module = OpticsModule()
         module._initialized = False
@@ -79,11 +72,11 @@ class TestOpticsModule(unittest.TestCase):
 
     def test_register_property_from_sequence(self):
         module = OpticsModule()
-        value = [1.0, 2.0, 3.0]
-        module.register_optics_property("prop1", value, shape=(3,))
+        value = [1.0, 2.0]
+        module.register_optics_property("prop1", value, is_vector2=True)
         self.assertTrue(hasattr(module, "prop1"))
         self.assertIsInstance(module.prop1, Tensor)
-        expected_tensor = torch.tensor([1.0, 2.0, 3.0], dtype=torch.double)
+        expected_tensor = torch.tensor([1.0, 2.0], dtype=torch.double)
         self.assertTrue(torch.equal(module.prop1, expected_tensor))
         self.assertFalse(module.prop1.requires_grad)
         self.assertIn("prop1", dict(module.named_buffers()))
@@ -108,9 +101,9 @@ class TestOpticsModule(unittest.TestCase):
 
     def test_set_property_via_setattr(self):
         module = OpticsModule()
-        initial_value = [1.0, 2.0, 3.0]
-        module.register_optics_property("prop1", initial_value, shape=(3,))
-        new_value = [4.0, 5.0, 6.0]
+        initial_value = [1.0, 2.0]
+        module.register_optics_property("prop1", initial_value, is_vector2=True)
+        new_value = [4.0, 5.0]
         module.prop1 = new_value  # Using setattr
         expected_tensor = torch.tensor(new_value, dtype=torch.double)
         self.assertTrue(torch.equal(module.prop1, expected_tensor))
@@ -118,7 +111,7 @@ class TestOpticsModule(unittest.TestCase):
     def test_set_property_via_setattr_tensor(self):
         module = OpticsModule()
         initial_value = [1.0, 2.0, 3.0]
-        module.register_optics_property("prop1", initial_value, shape=(3,))
+        module.register_optics_property("prop1", initial_value)
         new_value = torch.tensor([4.0, 5.0, 6.0])
         module.prop1 = new_value  # Using setattr
         self.assertTrue(torch.equal(module.prop1, new_value))
@@ -126,7 +119,7 @@ class TestOpticsModule(unittest.TestCase):
     def test_set_trainable_property_via_setattr(self):
         module = OpticsModule()
         initial_value = torch.tensor([1.0, 2.0, 3.0])
-        module.register_optics_property("prop1", Parameter(initial_value), shape=(3,))
+        module.register_optics_property("prop1", Parameter(initial_value))
         new_value = [4.0, 5.0, 6.0]
         # Prevents RuntimeError: a leaf Variable that requires grad is being used in an in-place operation.
         with torch.no_grad():
@@ -135,12 +128,8 @@ class TestOpticsModule(unittest.TestCase):
         self.assertTrue(torch.equal(module.prop1, expected_tensor))
 
     def test_raise_errors(self):
-        with self.assertRaises(ValueError):
-            OpticsModule().register_optics_property("prop1", 1.0)
         with self.assertRaises(AttributeError):
             OpticsModule().set_optics_property("unregistered_prop", 1.0)
-        with self.assertRaises(ValueError):
-            OpticsModule().register_optics_property("complex_prop", 1.0, is_complex=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from torchoptics.utils import *
+
+
+class TestInitializetensor(unittest.TestCase):
+    def test_initialize_tensor(self):
+        with self.assertRaises(ValueError):
+            initialize_tensor("name", 1.0, is_scalar=True, is_complex=True, is_integer=True)
+        with self.assertRaises(ValueError):
+            initialize_tensor("name", 1.1, is_scalar=True, is_complex=False, is_integer=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import unittest
 
+import torch
+
 from torchoptics.utils import *
 
 
@@ -9,3 +11,57 @@ class TestInitializetensor(unittest.TestCase):
             initialize_tensor("name", 1.0, is_scalar=True, is_complex=True, is_integer=True)
         with self.assertRaises(ValueError):
             initialize_tensor("name", 1.1, is_scalar=True, is_complex=False, is_integer=True)
+
+    def test_initialize_scalar_tensor(self):
+        tensor = initialize_tensor("scalar", 1.0, is_scalar=True)
+        self.assertTrue(torch.is_tensor(tensor))
+        self.assertEqual(tensor.item(), 1.0)
+
+    def test_scalar_and_vector2(self):
+        with self.assertRaises(ValueError):
+            initialize_tensor("scalar_and_vector2", 1.0, is_scalar=True, is_vector2=True)
+
+    def test_initialize_vector2_tensor(self):
+        tensor = initialize_tensor("vector2", [1.0, 2.0], is_vector2=True)
+        self.assertTrue(torch.is_tensor(tensor))
+        self.assertEqual(tensor.tolist(), [1.0, 2.0])
+
+    def test_initialize_complex_tensor(self):
+        tensor = initialize_tensor("complex", 1.0 + 2.0j, is_complex=True)
+        self.assertTrue(torch.is_tensor(tensor))
+        self.assertEqual(tensor.item(), 1.0 + 2.0j)
+
+    def test_initialize_integer_tensor(self):
+        tensor = initialize_tensor("integer", 1, is_integer=True)
+        self.assertTrue(torch.is_tensor(tensor))
+        self.assertEqual(tensor.item(), 1)
+
+    def test_initialize_positive_tensor(self):
+        tensor = initialize_tensor("positive", 1.0, is_positive=True)
+        self.assertTrue(torch.is_tensor(tensor))
+        self.assertEqual(tensor.item(), 1.0)
+
+    def test_initialize_non_negative_tensor(self):
+        tensor = initialize_tensor("non_negative", 0.0, is_non_negative=True)
+        self.assertTrue(torch.is_tensor(tensor))
+        self.assertEqual(tensor.item(), 0.0)
+
+    def test_initialize_tensor_invalid_scalar(self):
+        with self.assertRaises(ValueError):
+            initialize_tensor("invalid_scalar", [1.0, 2.0], is_scalar=True)
+
+    def test_initialize_tensor_invalid_vector2(self):
+        with self.assertRaises(ValueError):
+            initialize_tensor("invalid_vector2", [1.0, 2.0, 3.0], is_vector2=True)
+
+    def test_initialize_tensor_invalid_positive(self):
+        with self.assertRaises(ValueError):
+            initialize_tensor("invalid_positive", -1.0, is_positive=True)
+
+    def test_initialize_tensor_invalid_non_negative(self):
+        with self.assertRaises(ValueError):
+            initialize_tensor("invalid_non_negative", -1.0, is_non_negative=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 
 from torchoptics.utils import *
 

--- a/torchoptics/config.py
+++ b/torchoptics/config.py
@@ -35,7 +35,7 @@ def set_default_spacing(value: Vector2) -> None:
     Example:
         >>> torchoptics.set_default_spacing((10e-6, 10e-6))
     """
-    Config.spacing = initialize_tensor("spacing", value, (2,), validate_positive=True, fill_value=True)
+    Config.spacing = initialize_tensor("spacing", value, (2,), is_positive=True, fill_value=True)
 
 
 def get_default_wavelength() -> Tensor:
@@ -56,7 +56,7 @@ def set_default_wavelength(value: Scalar) -> None:
     Example:
         >>> torchoptics.set_default_wavelength(700e-6)
     """
-    Config.wavelength = initialize_tensor("wavelength", value, (), validate_positive=True)
+    Config.wavelength = initialize_tensor("wavelength", value, (), is_positive=True)
 
 
 def spacing_or_default(spacing: Optional[Vector2]) -> Tensor:
@@ -64,7 +64,7 @@ def spacing_or_default(spacing: Optional[Vector2]) -> Tensor:
     return (
         get_default_spacing()
         if spacing is None
-        else initialize_tensor("spacing", spacing, (2,), validate_positive=True, fill_value=True)
+        else initialize_tensor("spacing", spacing, (2,), is_positive=True, fill_value=True)
     )
 
 
@@ -73,5 +73,5 @@ def wavelength_or_default(wavelength: Optional[Scalar]) -> Tensor:
     return (
         get_default_wavelength()
         if wavelength is None
-        else initialize_tensor("wavelength", wavelength, (), validate_positive=True)
+        else initialize_tensor("wavelength", wavelength, (), is_positive=True)
     )

--- a/torchoptics/config.py
+++ b/torchoptics/config.py
@@ -4,8 +4,8 @@ from typing import Optional
 
 from torch import Tensor
 
-from .functional import initialize_tensor
 from .type_defs import Scalar, Vector2
+from .utils import initialize_tensor
 
 __all__ = ["get_default_spacing", "set_default_spacing", "get_default_wavelength", "set_default_wavelength"]
 

--- a/torchoptics/config.py
+++ b/torchoptics/config.py
@@ -35,7 +35,7 @@ def set_default_spacing(value: Vector2) -> None:
     Example:
         >>> torchoptics.set_default_spacing((10e-6, 10e-6))
     """
-    Config.spacing = initialize_tensor("spacing", value, (2,), is_positive=True, fill_value=True)
+    Config.spacing = initialize_tensor("spacing", value, is_vector2=True, is_positive=True)
 
 
 def get_default_wavelength() -> Tensor:
@@ -56,7 +56,7 @@ def set_default_wavelength(value: Scalar) -> None:
     Example:
         >>> torchoptics.set_default_wavelength(700e-6)
     """
-    Config.wavelength = initialize_tensor("wavelength", value, (), is_positive=True)
+    Config.wavelength = initialize_tensor("wavelength", value, is_scalar=True, is_positive=True)
 
 
 def spacing_or_default(spacing: Optional[Vector2]) -> Tensor:
@@ -64,7 +64,7 @@ def spacing_or_default(spacing: Optional[Vector2]) -> Tensor:
     return (
         get_default_spacing()
         if spacing is None
-        else initialize_tensor("spacing", spacing, (2,), is_positive=True, fill_value=True)
+        else initialize_tensor("spacing", spacing, is_vector2=True, is_positive=True)
     )
 
 
@@ -73,5 +73,5 @@ def wavelength_or_default(wavelength: Optional[Scalar]) -> Tensor:
     return (
         get_default_wavelength()
         if wavelength is None
-        else initialize_tensor("wavelength", wavelength, (), is_positive=True)
+        else initialize_tensor("wavelength", wavelength, is_scalar=True, is_positive=True)
     )

--- a/torchoptics/elements/beam_splitters.py
+++ b/torchoptics/elements/beam_splitters.py
@@ -62,10 +62,10 @@ class BeamSplitter(Element):
         offset: Optional[Vector2] = None,
     ) -> None:
         super().__init__(shape, z, spacing, offset)
-        self.register_optics_property("theta", theta, ())
-        self.register_optics_property("phi_0", phi_0, ())
-        self.register_optics_property("phi_r", phi_r, ())
-        self.register_optics_property("phi_t", phi_t, ())
+        self.register_optics_property("theta", theta, is_scalar=True)
+        self.register_optics_property("phi_0", phi_0, is_scalar=True)
+        self.register_optics_property("phi_r", phi_r, is_scalar=True)
+        self.register_optics_property("phi_t", phi_t, is_scalar=True)
 
     @property
     def transfer_matrix(self) -> Tensor:

--- a/torchoptics/elements/beam_splitters.py
+++ b/torchoptics/elements/beam_splitters.py
@@ -88,11 +88,11 @@ class BeamSplitter(Element):
         Returns:
             tuple[Field, Field]: The split fields.
         """
-        self.validate_field_geometry(field)
+        self.validate_field(field)
         output_data0 = field.data * self.transfer_matrix[0, 0]
         output_data1 = field.data * self.transfer_matrix[1, 0]
         if other:
-            self.validate_field_geometry(other)
+            self.validate_field(other)
             output_data0 += other.data * self.transfer_matrix[0, 1]
             output_data1 += other.data * self.transfer_matrix[1, 1]
 
@@ -116,7 +116,7 @@ class PolarizingBeamSplitter(Element):
         Returns:
             tuple[PolarizedField, PolarizedField]: The split fields.
         """
-        self.validate_field_geometry(field)
+        self.validate_field(field)
         if not torch.all(field.data.select(-3, 2) == 0):
             raise ValueError("Polarized field cannot have z polarization.")
         return field.polarized_split()[:2]

--- a/torchoptics/elements/detectors.py
+++ b/torchoptics/elements/detectors.py
@@ -45,7 +45,7 @@ class Detector(Element):
         Returns:
             Tensor: The power per cell area.
         """
-        self.validate_field_geometry(field)  # TODO: Move this to utils?
+        self.validate_field(field)  # TODO: Move this to utils?
         return field.intensity() * self.cell_area()
 
 
@@ -102,7 +102,7 @@ class IntensityDetector(Element):
         Returns:
             Tensor: The weighted power.
         """
-        self.validate_field_geometry(field)  # TODO: Move this to utils?
+        self.validate_field(field)  # TODO: Move this to utils?
         intensity_flat, weight_flat = field.intensity().flatten(-2), self.weight.flatten(-2)
         return linear(intensity_flat, weight_flat) * self.cell_area()  # pylint: disable=not-callable
 
@@ -162,7 +162,7 @@ class FieldDetector(IntensityDetector):
         Returns:
             Tensor: The weighted power after applying the inner product and calculating the magnitude squared.
         """
-        self.validate_field_geometry(field)  # TODO: Move this to utils?
+        self.validate_field(field)  # TODO: Move this to utils?
         data_flat, weight_flat = field.data.flatten(-2), self.weight.flatten(-2)
         inner_prod = linear(data_flat, weight_flat) * self.cell_area()  # pylint: disable=not-callable
         return inner_prod.abs().square()

--- a/torchoptics/elements/elements.py
+++ b/torchoptics/elements/elements.py
@@ -26,7 +26,7 @@ class Element(PlanarGeometry):  # pylint: disable=abstract-method
         offset (Optional[Vector2]): Center coordinates of the plane. Default: `(0, 0)`.
     """
 
-    def validate_field_geometry(self, field: Field) -> None:
+    def validate_field(self, field: Field) -> None:
         """
         Validates that the field has the same geometry as the element.
 
@@ -67,7 +67,7 @@ class ModulationElement(Element, ABC):
 
         Returns:
             Field: The modulated field."""
-        self.validate_field_geometry(field)
+        self.validate_field(field)
         return field.modulate(self.modulation_profile())
 
     def visualize(self, **kwargs) -> Any:
@@ -108,7 +108,7 @@ class PolychromaticModulationElement(Element):
 
         Returns:
             Field: The modulated field."""
-        self.validate_field_geometry(field)
+        self.validate_field(field)
         return field.modulate(self.modulation_profile(field.wavelength))
 
     def visualize(self, wavelength: Optional[Scalar] = None, **kwargs) -> Any:
@@ -149,7 +149,7 @@ class PolarizedModulationElement(Element):
 
         Returns:
             PolarizedField: The modulated polarized field."""
-        self.validate_field_geometry(field)
+        self.validate_field(field)
         return field.polarized_modulate(self.polarized_modulation_profile())
 
     def visualize(self, *index: int, **kwargs) -> Any:

--- a/torchoptics/elements/identity_element.py
+++ b/torchoptics/elements/identity_element.py
@@ -23,5 +23,5 @@ class IdentityElement(Element):
 
     def forward(self, field: Field) -> Field:
         """Returns the input field without modification."""
-        self.validate_field_geometry(field)
+        self.validate_field(field)
         return field

--- a/torchoptics/elements/lens.py
+++ b/torchoptics/elements/lens.py
@@ -47,7 +47,7 @@ class Lens(PolychromaticModulationElement):
         is_circular_lens: bool = True,
     ) -> None:
         super().__init__(shape, z, spacing, offset)
-        self.register_optics_property("focal_length", focal_length, ())
+        self.register_optics_property("focal_length", focal_length, is_scalar=True)
         self.is_circular_lens = is_circular_lens
 
     def modulation_profile(self, wavelength: Optional[Scalar] = None) -> Tensor:

--- a/torchoptics/elements/modulators.py
+++ b/torchoptics/elements/modulators.py
@@ -7,6 +7,7 @@ from torch import Tensor
 
 from ..config import wavelength_or_default
 from ..type_defs import Scalar, Vector2
+from ..utils import validate_tensor_dim
 from .elements import ModulationElement, PolychromaticModulationElement
 
 __all__ = ["Modulator", "PhaseModulator", "AmplitudeModulator", "PolychromaticPhaseModulator"]
@@ -35,7 +36,7 @@ class Modulator(ModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        _validate_input_tensor("modulation", modulation)
+        validate_tensor_dim(modulation, "modulation", 2)
         super().__init__(modulation.shape, z, spacing, offset)
         self.register_optics_property("modulation", modulation, is_complex=True)
 
@@ -66,7 +67,7 @@ class PhaseModulator(ModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        _validate_input_tensor("phase", phase)
+        validate_tensor_dim(phase, "phase", 2)
         super().__init__(phase.shape, z, spacing, offset)
         self.register_optics_property("phase", phase)
 
@@ -97,7 +98,7 @@ class AmplitudeModulator(ModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        _validate_input_tensor("amplitude", amplitude)
+        validate_tensor_dim(amplitude, "amplitude", 2)
         super().__init__(amplitude.shape, z, spacing, offset)
         self.register_optics_property("amplitude", amplitude)
 
@@ -128,17 +129,10 @@ class PolychromaticPhaseModulator(PolychromaticModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        _validate_input_tensor("optical_path_length", optical_path_length)
+        validate_tensor_dim(optical_path_length, "optical_path_length", 2)
         super().__init__(optical_path_length.shape, z, spacing, offset)
         self.register_optics_property("optical_path_length", optical_path_length)
 
     def modulation_profile(self, wavelength: Optional[Scalar] = None) -> Tensor:
         wavelength = wavelength_or_default(wavelength)
         return torch.exp(2j * torch.pi / wavelength * self.optical_path_length)
-
-
-def _validate_input_tensor(name, tensor):
-    if not isinstance(tensor, Tensor):
-        raise TypeError(f"Expected {name} to be a tensor, but got {type(tensor).__name__}")
-    if tensor.dim() != 2:
-        raise ValueError(f"Expected {name} to be a 2D tensor, but got {tensor.dim()}D")

--- a/torchoptics/elements/polarized_modulators.py
+++ b/torchoptics/elements/polarized_modulators.py
@@ -6,6 +6,7 @@ import torch
 from torch import Tensor
 
 from ..type_defs import Scalar, Vector2
+from ..utils import validate_tensor_dim
 from .elements import PolarizedModulationElement
 
 __all__ = ["PolarizedModulator", "PolarizedPhaseModulator", "PolarizedAmplitudeModulator"]
@@ -34,7 +35,7 @@ class PolarizedModulator(PolarizedModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        _validate_input_tensor(polarized_modulation, "polarized_modulation")
+        _validate_tensor(polarized_modulation, "polarized_modulation")
         super().__init__(polarized_modulation.shape[2:], z, spacing, offset)
         self.register_optics_property("polarized_modulation", polarized_modulation, is_complex=True)
 
@@ -65,7 +66,7 @@ class PolarizedPhaseModulator(PolarizedModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        _validate_input_tensor(phase, "phase")
+        _validate_tensor(phase, "phase")
         super().__init__(phase.shape[2:], z, spacing, offset)
         self.register_optics_property("phase", phase)
 
@@ -96,7 +97,7 @@ class PolarizedAmplitudeModulator(PolarizedModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        _validate_input_tensor(amplitude, "amplitude")
+        _validate_tensor(amplitude, "amplitude")
         super().__init__(amplitude.shape[2:], z, spacing, offset)
         self.register_optics_property("amplitude", amplitude)
 
@@ -104,11 +105,8 @@ class PolarizedAmplitudeModulator(PolarizedModulationElement):
         return self.amplitude.cdouble()  # type: ignore
 
 
-def _validate_input_tensor(tensor, name):
-    if not isinstance(tensor, Tensor):
-        raise TypeError(f"Expected {name} to be a tensor, but got {type(tensor).__name__}")
-    if tensor.dim() != 4:
-        raise ValueError(f"Expected {name} to be a 4D tensor, but got {tensor.dim()}D")
+def _validate_tensor(tensor, name):
+    validate_tensor_dim(tensor, name, 4)
     if tensor.shape[:2] != (3, 3):
         raise ValueError(
             f"Expected first two dimensions of {name} to have shape (3, 3), but got {tensor.shape[:2]}"

--- a/torchoptics/elements/polarizers.py
+++ b/torchoptics/elements/polarizers.py
@@ -47,7 +47,7 @@ class LinearPolarizer(PolarizedModulationElement):
         offset: Optional[Vector2] = None,
     ) -> None:
         super().__init__(shape, z, spacing, offset)
-        self.register_optics_property("theta", theta, ())
+        self.register_optics_property("theta", theta, is_scalar=True)
 
     def polarized_modulation_profile(self) -> Tensor:
         tensor = torch.zeros(3, 3, *self.shape, dtype=torch.cdouble, device=next(self.buffers()).device)

--- a/torchoptics/elements/waveplates.py
+++ b/torchoptics/elements/waveplates.py
@@ -57,8 +57,8 @@ class Waveplate(PolarizedModulationElement):
         offset: Optional[Vector2] = None,
     ) -> None:
         super().__init__(shape, z, spacing, offset)
-        self.register_optics_property("phi", phi, ())
-        self.register_optics_property("theta", theta, ())
+        self.register_optics_property("phi", phi, is_scalar=True)
+        self.register_optics_property("theta", theta, is_scalar=True)
 
     def polarized_modulation_profile(self) -> Tensor:
         tensor = torch.zeros(3, 3, *self.shape, dtype=torch.cdouble, device=next(self.buffers()).device)
@@ -107,7 +107,7 @@ class QuarterWaveplate(PolarizedModulationElement):
         offset: Optional[Vector2] = None,
     ) -> None:
         super().__init__(shape, z, spacing, offset)
-        self.register_optics_property("theta", theta, ())
+        self.register_optics_property("theta", theta, is_scalar=True)
 
     def polarized_modulation_profile(self) -> Tensor:
         tensor = torch.zeros(3, 3, *self.shape, dtype=torch.cdouble, device=next(self.buffers()).device)
@@ -156,7 +156,7 @@ class HalfWaveplate(PolarizedModulationElement):
         offset: Optional[Vector2] = None,
     ) -> None:
         super().__init__(shape, z, spacing, offset)
-        self.register_optics_property("theta", theta, ())
+        self.register_optics_property("theta", theta, is_scalar=True)
 
     def polarized_modulation_profile(self) -> Tensor:
         tensor = torch.zeros(3, 3, *self.shape, dtype=torch.cdouble, device=next(self.buffers()).device)

--- a/torchoptics/fields.py
+++ b/torchoptics/fields.py
@@ -53,7 +53,9 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
         self._validate_data(data)
         super().__init__(data.shape[-2:], z, spacing, offset)
         self.register_optics_property("data", data, is_complex=True)
-        self.register_optics_property("wavelength", wavelength_or_default(wavelength), (), is_positive=True)
+        self.register_optics_property(
+            "wavelength", wavelength_or_default(wavelength), is_scalar=True, is_positive=True
+        )
 
         self.propagation_method = propagation_method
         self.asm_pad_factor = asm_pad_factor  # type: ignore[assignment]
@@ -82,7 +84,7 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
     @asm_pad_factor.setter
     def asm_pad_factor(self, value: Vector2) -> None:
         tensor = initialize_tensor(
-            "asm_pad_factor", value, (2,), is_integer=True, is_non_negative=True, fill_value=True
+            "asm_pad_factor", value, is_vector2=True, is_integer=True, is_non_negative=True
         )
         self._asm_pad_factor = (tensor[0].item(), tensor[1].item())
 

--- a/torchoptics/fields.py
+++ b/torchoptics/fields.py
@@ -53,9 +53,7 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
         self._validate_data(data)
         super().__init__(data.shape[-2:], z, spacing, offset)
         self.register_optics_property("data", data, is_complex=True)
-        self.register_optics_property(
-            "wavelength", wavelength_or_default(wavelength), (), validate_positive=True
-        )
+        self.register_optics_property("wavelength", wavelength_or_default(wavelength), (), is_positive=True)
 
         self.propagation_method = propagation_method
         self.asm_pad_factor = asm_pad_factor  # type: ignore[assignment]
@@ -84,7 +82,7 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
     @asm_pad_factor.setter
     def asm_pad_factor(self, value: Vector2) -> None:
         tensor = initialize_tensor(
-            "asm_pad_factor", value, (2,), is_integer=True, validate_non_negative=True, fill_value=True
+            "asm_pad_factor", value, (2,), is_integer=True, is_non_negative=True, fill_value=True
         )
         self._asm_pad_factor = (tensor[0].item(), tensor[1].item())
 

--- a/torchoptics/fields.py
+++ b/torchoptics/fields.py
@@ -8,10 +8,11 @@ import torch
 from torch import Tensor
 
 from .config import wavelength_or_default
-from .functional import calculate_centroid, calculate_std, initialize_tensor, inner2d, outer2d
+from .functional import calculate_centroid, calculate_std, inner2d, outer2d
 from .planar_geometry import PlanarGeometry
 from .propagation import VALID_INTERPOLATION_MODES, VALID_PROPAGATION_METHODS, propagator
 from .type_defs import Scalar, Vector2
+from .utils import initialize_tensor
 
 __all__ = ["Field", "PolarizedField", "CoherenceField"]
 

--- a/torchoptics/functional/functional.py
+++ b/torchoptics/functional/functional.py
@@ -17,7 +17,6 @@ __all__ = [
     "calculate_std",
     "conv2d_fft",
     "fftfreq_grad",
-    "initialize_tensor",
     "inner2d",
     "linspace_grad",
     "meshgrid2d",
@@ -88,63 +87,6 @@ def fftfreq_grad(n: int, d: Tensor) -> Tensor:
     val = torch.arange(0, n, device=d.device, dtype=d.dtype)
     k = torch.where(val < (n // 2), val, val - n)
     return k * (1.0 / (n * d))
-
-
-def initialize_tensor(
-    name: str,
-    value: Any,
-    is_scalar: bool = False,
-    is_vector2: bool = False,
-    is_complex: bool = False,
-    is_integer: bool = False,
-    is_positive: bool = False,
-    is_non_negative: bool = False,
-) -> Tensor:
-    """
-    Initializes a tensor with validation checks.
-
-    Args:
-        name (str): The name of the tensor.
-        value (Any): The value to initialize the tensor with.
-        is_scalar (bool): If `True`, the tensor is a scalar.
-        is_vector2 (bool): If `True`, the tensor is a 2D vector.
-        is_complex (bool, optional): If `True`, the tensor is complex. Default: `False`.
-        is_integer (bool, optional): If `True`, the tensor is integer. Default: `False`.
-        is_positive (bool, optional): If `True`, validates the tensor is positive. Default: `False`.
-        is_non_negative (bool, optional): If `True`, validates the tensor is non-negative. Default: `False`.
-    """
-    if is_complex and is_integer:
-        raise ValueError("Expected is_complex and is_integer to be mutually exclusive, but both are True.")
-    if is_scalar and is_vector2:
-        raise ValueError("Expected is_scalar and is_vector2 to be mutually exclusive, but both are True.")
-
-    value_dtype = torch.as_tensor(value).dtype
-    if is_integer and value_dtype not in (torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8):
-        raise ValueError(f"Expected {name} to contain integer values, but found non-integer values.")
-
-    dtype = torch.int if is_integer else torch.cdouble if is_complex else torch.double
-    tensor = value.clone().to(dtype) if isinstance(value, Tensor) else torch.tensor(value, dtype=dtype)
-
-    if is_scalar:
-        if tensor.numel() != 1:
-            raise ValueError(f"Expected {name} to be a scalar, but got a tensor with shape {tensor.shape}.")
-        tensor = tensor.squeeze()
-
-    if is_vector2:
-        if tensor.numel() == 1:  # Convert scalar to 2D vector
-            tensor = torch.full((2,), tensor.item())
-        if tensor.numel() != 2:
-            raise ValueError(
-                f"Expected {name} to be a 2D vector, but got a tensor with shape {tensor.shape}."
-            )
-        tensor = tensor.squeeze()
-
-    if is_positive and not torch.all(tensor > 0):
-        raise ValueError(f"Expected {name} to contain positive values, but found non-positive values.")
-    if is_non_negative and not torch.all(tensor >= 0):
-        raise ValueError(f"Expected {name} to contain non-negative values, but found negative values.")
-
-    return tensor
 
 
 def inner2d(vec1: Tensor, vec2: Tensor) -> Tensor:

--- a/torchoptics/functional/functional.py
+++ b/torchoptics/functional/functional.py
@@ -96,8 +96,8 @@ def initialize_tensor(
     shape: Sequence,
     is_complex: bool = False,
     is_integer: bool = False,
-    validate_positive: bool = False,
-    validate_non_negative: bool = False,
+    is_positive: bool = False,
+    is_non_negative: bool = False,
     fill_value: bool = False,
 ) -> Tensor:
     """
@@ -109,8 +109,8 @@ def initialize_tensor(
         shape (Sequence): The shape of the tensor.
         is_complex (bool, optional): If `True`, the tensor is complex. Default: `False`.
         is_integer (bool, optional): If `True`, the tensor is integer. Default: `False`.
-        validate_positive (bool, optional): If `True`, validates the tensor is positive. Default: `False`.
-        validate_non_negative (bool, optional): If `True`, validates the tensor is non-negative. Default:
+        is_positive (bool, optional): If `True`, validates the tensor is positive. Default: `False`.
+        is_non_negative (bool, optional): If `True`, validates the tensor is non-negative. Default:
             `False`.
         fill_value (bool, optional): If `True`, fills the tensor with the value. Default: `False`.
     """
@@ -126,9 +126,9 @@ def initialize_tensor(
         raise ValueError(f"Expected {name} to have shape {shape}, but got {tensor.shape}.")
     if is_integer and not torch.all(tensor == torch.floor(tensor)):
         raise ValueError(f"Expected {name} to contain integer values, but found non-integer values.")
-    if validate_positive and not torch.all(tensor > 0):
+    if is_positive and not torch.all(tensor > 0):
         raise ValueError(f"Expected {name} to contain positive values, but found non-positive values.")
-    if validate_non_negative and not torch.all(tensor >= 0):
+    if is_non_negative and not torch.all(tensor >= 0):
         raise ValueError(f"Expected {name} to contain non-negative values, but found negative values.")
 
     if is_integer:

--- a/torchoptics/functional/functional.py
+++ b/torchoptics/functional/functional.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Sequence, Union
 
 import torch
 from torch import Tensor

--- a/torchoptics/optics_module.py
+++ b/torchoptics/optics_module.py
@@ -64,8 +64,8 @@ class OpticsModule(Module):  # pylint: disable=abstract-method
         value: Any,
         shape: Optional[Sequence] = None,
         is_complex: bool = False,
-        validate_positive: bool = False,
-        validate_non_negative: bool = False,
+        is_positive: bool = False,
+        is_non_negative: bool = False,
         fill_value: bool = False,
     ) -> None:
         """
@@ -77,9 +77,9 @@ class OpticsModule(Module):  # pylint: disable=abstract-method
             shape (Optional[Sequence]): Shape of the property tensor. Required if value is not a tensor.
                 Default: `None`.
             is_complex (bool): Whether the property tensor is complex. Default: `False`.
-            validate_positive (bool): Whether to validate that the property tensor contains only positive
+            is_positive (bool): Whether to validate that the property tensor contains only positive
                 values. Default: `False`.
-            validate_non_negative (bool): Whether to validate that the property tensor contains only
+            is_non_negative (bool): Whether to validate that the property tensor contains only
                 non-negative. Default: `False`.
             fill_value (bool): Whether to fill the tensor with the initial value if it is a scalar.
                 Default: `False`.
@@ -101,8 +101,8 @@ class OpticsModule(Module):  # pylint: disable=abstract-method
             "name": name,
             "shape": shape,
             "is_complex": is_complex,
-            "validate_positive": validate_positive,
-            "validate_non_negative": validate_non_negative,
+            "is_positive": is_positive,
+            "is_non_negative": is_non_negative,
             "fill_value": fill_value,
         }
         self._optics_property_configs[name] = property_config

--- a/torchoptics/optics_module.py
+++ b/torchoptics/optics_module.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from torch.nn import Module, Parameter
 
-from .functional import initialize_tensor
+from .utils import initialize_tensor
 
 __all__ = ["OpticsModule"]
 

--- a/torchoptics/planar_geometry.py
+++ b/torchoptics/planar_geometry.py
@@ -8,9 +8,10 @@ import torch
 from torch import Tensor
 
 from .config import spacing_or_default
-from .functional import initialize_tensor, meshgrid2d
+from .functional import meshgrid2d
 from .optics_module import OpticsModule
 from .type_defs import Scalar, Vector2
+from .utils import initialize_tensor
 from .visualization import visualize_tensor
 
 __all__ = ["PlanarGeometry"]

--- a/torchoptics/planar_geometry.py
+++ b/torchoptics/planar_geometry.py
@@ -44,11 +44,11 @@ class PlanarGeometry(OpticsModule):  # pylint: disable=abstract-method
     ) -> None:
         super().__init__()
         self._shape = torch.Size(
-            initialize_tensor("shape", shape, (2,), is_integer=True, validate_positive=True, fill_value=True)
+            initialize_tensor("shape", shape, (2,), is_integer=True, is_positive=True, fill_value=True)
         )
         self.register_optics_property("z", z, ())
         self.register_optics_property(
-            "spacing", spacing_or_default(spacing), (2,), validate_positive=True, fill_value=True
+            "spacing", spacing_or_default(spacing), (2,), is_positive=True, fill_value=True
         )
         self.register_optics_property("offset", (0, 0) if offset is None else offset, (2,))
 

--- a/torchoptics/planar_geometry.py
+++ b/torchoptics/planar_geometry.py
@@ -44,13 +44,13 @@ class PlanarGeometry(OpticsModule):  # pylint: disable=abstract-method
     ) -> None:
         super().__init__()
         self._shape = torch.Size(
-            initialize_tensor("shape", shape, (2,), is_integer=True, is_positive=True, fill_value=True)
+            initialize_tensor("shape", shape, is_vector2=True, is_integer=True, is_positive=True)
         )
-        self.register_optics_property("z", z, ())
+        self.register_optics_property("z", z, is_scalar=True)
         self.register_optics_property(
-            "spacing", spacing_or_default(spacing), (2,), is_positive=True, fill_value=True
+            "spacing", spacing_or_default(spacing), is_vector2=True, is_positive=True
         )
-        self.register_optics_property("offset", (0, 0) if offset is None else offset, (2,))
+        self.register_optics_property("offset", (0, 0) if offset is None else offset, is_vector2=True)
 
     @property
     def shape(self) -> torch.Size:

--- a/torchoptics/profiles/shapes.py
+++ b/torchoptics/profiles/shapes.py
@@ -5,9 +5,9 @@ from typing import Optional
 import torch
 from torch import Tensor
 
-from ..functional import initialize_tensor
 from ..planar_geometry import PlanarGeometry
-from ..type_defs import Vector2, Scalar
+from ..type_defs import Scalar, Vector2
+from ..utils import initialize_tensor
 
 __all__ = ["checkerboard", "circle", "rectangle", "square"]
 

--- a/torchoptics/profiles/shapes.py
+++ b/torchoptics/profiles/shapes.py
@@ -34,9 +34,9 @@ def checkerboard(
         Tensor: The generated checkerboard pattern with internal padding.
     """
     x, y = PlanarGeometry(shape, 0, spacing, offset).meshgrid()
-    tile_length = initialize_tensor("tile_length", tile_length, (2,), validate_positive=True, fill_value=True)
+    tile_length = initialize_tensor("tile_length", tile_length, (2,), is_positive=True, fill_value=True)
     num_tiles = initialize_tensor(
-        "num_tiles", num_tiles, (2,), is_integer=True, validate_positive=True, fill_value=True
+        "num_tiles", num_tiles, (2,), is_integer=True, is_positive=True, fill_value=True
     )
 
     x_tile = (x + (tile_length[0] / 2 if num_tiles[0] % 2 == 1 else 0)) // tile_length[0]
@@ -87,7 +87,7 @@ def rectangle(
         Tensor: The generated rectangle profile.
     """
     x, y = PlanarGeometry(shape, 0, spacing, offset).meshgrid()
-    side = initialize_tensor("side", side, (2,), validate_positive=True, fill_value=True)
+    side = initialize_tensor("side", side, (2,), is_positive=True, fill_value=True)
     return (x.abs() <= side[0] / 2) & (y.abs() <= side[1] / 2)
 
 

--- a/torchoptics/profiles/shapes.py
+++ b/torchoptics/profiles/shapes.py
@@ -34,10 +34,8 @@ def checkerboard(
         Tensor: The generated checkerboard pattern with internal padding.
     """
     x, y = PlanarGeometry(shape, 0, spacing, offset).meshgrid()
-    tile_length = initialize_tensor("tile_length", tile_length, (2,), is_positive=True, fill_value=True)
-    num_tiles = initialize_tensor(
-        "num_tiles", num_tiles, (2,), is_integer=True, is_positive=True, fill_value=True
-    )
+    tile_length = initialize_tensor("tile_length", tile_length, is_vector2=True, is_positive=True)
+    num_tiles = initialize_tensor("num_tiles", num_tiles, is_vector2=True, is_integer=True, is_positive=True)
 
     x_tile = (x + (tile_length[0] / 2 if num_tiles[0] % 2 == 1 else 0)) // tile_length[0]
     y_tile = (y + (tile_length[1] / 2 if num_tiles[1] % 2 == 1 else 0)) // tile_length[1]
@@ -87,7 +85,7 @@ def rectangle(
         Tensor: The generated rectangle profile.
     """
     x, y = PlanarGeometry(shape, 0, spacing, offset).meshgrid()
-    side = initialize_tensor("side", side, (2,), is_positive=True, fill_value=True)
+    side = initialize_tensor("side", side, is_vector2=True, is_positive=True)
     return (x.abs() <= side[0] / 2) & (y.abs() <= side[1] / 2)
 
 

--- a/torchoptics/profiles/special.py
+++ b/torchoptics/profiles/special.py
@@ -6,9 +6,9 @@ import torch
 from torch import Tensor
 from torch.special import bessel_j1  # Bessel function of the first kind
 
-from ..functional import initialize_tensor
 from ..planar_geometry import PlanarGeometry
-from ..type_defs import Vector2, Scalar
+from ..type_defs import Scalar, Vector2
+from ..utils import initialize_tensor
 
 __all__ = ["airy", "sinc"]
 

--- a/torchoptics/profiles/special.py
+++ b/torchoptics/profiles/special.py
@@ -76,6 +76,6 @@ def sinc(
         Tensor: The generated sinc profile.
     """
     x, y = PlanarGeometry(shape, 0, spacing, offset).meshgrid()
-    scale = initialize_tensor("scale", scale, (2,), fill_value=True, is_positive=True)
+    scale = initialize_tensor("scale", scale, is_vector2=True, is_positive=True)
     sinc_pattern = torch.sinc(x / scale[0]) * torch.sinc(y / scale[1]) / (scale[0] * scale[1]) ** 0.5
     return sinc_pattern

--- a/torchoptics/profiles/special.py
+++ b/torchoptics/profiles/special.py
@@ -76,6 +76,6 @@ def sinc(
         Tensor: The generated sinc profile.
     """
     x, y = PlanarGeometry(shape, 0, spacing, offset).meshgrid()
-    scale = initialize_tensor("scale", scale, (2,), fill_value=True, validate_positive=True)
+    scale = initialize_tensor("scale", scale, (2,), fill_value=True, is_positive=True)
     sinc_pattern = torch.sinc(x / scale[0]) * torch.sinc(y / scale[1]) / (scale[0] * scale[1]) ** 0.5
     return sinc_pattern

--- a/torchoptics/propagation/propagator.py
+++ b/torchoptics/propagation/propagator.py
@@ -138,8 +138,3 @@ def calculate_min_dim_propagation_distance(field: Field) -> float:
     - :math:`\lambda` is the wavelength of the field.
     """
     return ((field.length() * field.spacing).max() / field.wavelength).item()
-
-
-def calculate_power(field: Field) -> torch.Tensor:
-    """Function is necessary to properly calculate power for SpatialCoherence objects."""
-    return field.data.abs().square().sum(dim=(-1, -2)) * field.cell_area()

--- a/torchoptics/utils.py
+++ b/torchoptics/utils.py
@@ -1,0 +1,19 @@
+"""This module defines utility functions for TorchOptics."""
+
+from torch import Tensor
+
+
+def validate_tensor_dim(tensor: Tensor, name: str, dim: int) -> None:
+    """
+    Validates that a PyTorch tensor has the expected shape.
+
+    Args:
+        tensor (Tensor): The PyTorch tensor to validate.
+        name (str): The name of the tensor, used for error messages.
+        shape (tuple): The expected shape of the tensor. Use `-1` as a wildcard
+                       to allow any size in that dimension.
+    """
+    if not isinstance(tensor, Tensor):
+        raise TypeError(f"Expected '{name}' to be a Tensor, but got {type(tensor).__name__}")
+    if tensor.dim() != dim:
+        raise ValueError(f"Expected '{name}' to be a {dim}D tensor, but got {tensor.dim()}D")

--- a/torchoptics/utils.py
+++ b/torchoptics/utils.py
@@ -1,6 +1,66 @@
 """This module defines utility functions for TorchOptics."""
 
+from typing import Any
+
+import torch
 from torch import Tensor
+
+
+def initialize_tensor(
+    name: str,
+    value: Any,
+    is_scalar: bool = False,
+    is_vector2: bool = False,
+    is_complex: bool = False,
+    is_integer: bool = False,
+    is_positive: bool = False,
+    is_non_negative: bool = False,
+) -> Tensor:
+    """
+    Initializes a tensor with validation checks.
+
+    Args:
+        name (str): The name of the tensor.
+        value (Any): The value to initialize the tensor with.
+        is_scalar (bool): If `True`, the tensor is a scalar.
+        is_vector2 (bool): If `True`, the tensor is a 2D vector.
+        is_complex (bool, optional): If `True`, the tensor is complex. Default: `False`.
+        is_integer (bool, optional): If `True`, the tensor is integer. Default: `False`.
+        is_positive (bool, optional): If `True`, validates the tensor is positive. Default: `False`.
+        is_non_negative (bool, optional): If `True`, validates the tensor is non-negative. Default: `False`.
+    """
+    if is_complex and is_integer:
+        raise ValueError("Expected is_complex and is_integer to be mutually exclusive, but both are True.")
+    if is_scalar and is_vector2:
+        raise ValueError("Expected is_scalar and is_vector2 to be mutually exclusive, but both are True.")
+
+    value_dtype = torch.as_tensor(value).dtype
+    if is_integer and value_dtype not in (torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8):
+        raise ValueError(f"Expected {name} to contain integer values, but found non-integer values.")
+
+    dtype = torch.int if is_integer else torch.cdouble if is_complex else torch.double
+    tensor = value.clone().to(dtype) if isinstance(value, Tensor) else torch.tensor(value, dtype=dtype)
+
+    if is_scalar:
+        if tensor.numel() != 1:
+            raise ValueError(f"Expected {name} to be a scalar, but got a tensor with shape {tensor.shape}.")
+        tensor = tensor.squeeze()
+
+    if is_vector2:
+        if tensor.numel() == 1:  # Convert scalar to 2D vector
+            tensor = torch.full((2,), tensor.item())
+        if tensor.numel() != 2:
+            raise ValueError(
+                f"Expected {name} to be a 2D vector, but got a tensor with shape {tensor.shape}."
+            )
+        tensor = tensor.squeeze()
+
+    if is_positive and not torch.all(tensor > 0):
+        raise ValueError(f"Expected {name} to contain positive values, but found non-positive values.")
+    if is_non_negative and not torch.all(tensor >= 0):
+        raise ValueError(f"Expected {name} to contain non-negative values, but found negative values.")
+
+    return tensor
 
 
 def validate_tensor_dim(tensor: Tensor, name: str, dim: int) -> None:


### PR DESCRIPTION
Improve parameter naming for validation functions and streamline optics property registration. Move the `initialize_tensor` function to the utils module for better organization and update related imports.