### PR TITLE
Update propagation functions

### DIFF
--- a/torchoptics/fields.py
+++ b/torchoptics/fields.py
@@ -10,9 +10,8 @@ from torch import Tensor
 from .config import wavelength_or_default
 from .functional import calculate_centroid, calculate_std, inner2d, outer2d
 from .planar_geometry import PlanarGeometry
-from .propagation import VALID_INTERPOLATION_MODES, VALID_PROPAGATION_METHODS, propagator
+from .propagation import propagator
 from .type_defs import Scalar, Vector2
-from .utils import initialize_tensor
 
 __all__ = ["Field", "PolarizedField", "CoherenceField"]
 
@@ -29,10 +28,6 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
         spacing (Optional[Vector2]): Distance between grid points along planar dimensions. Default: if
             `None`, uses a global default (see :meth:`torchoptics.set_default_spacing()`).
         offset (Optional[Vector2]): Center coordinates of the plane. Default: `(0, 0)`.
-        propagation_method (str): The propagation method to use. Default: `"AUTO"`.
-        asm_pad_factor (Vector2): The padding factor along planar dimensions for angular spectrum method (ASM)
-            propagation. Default: `2`.
-        interpolation_mode (str): The interpolation mode to use. Default: `"nearest"`.
     """
 
     _data_min_dim = 2
@@ -46,9 +41,6 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
         z: Scalar = 0,
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
-        propagation_method: str = "AUTO",
-        asm_pad_factor: Vector2 = 2,
-        interpolation_mode: str = "nearest",
     ) -> None:
 
         self._validate_data(data)
@@ -56,60 +48,6 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
         self.register_optics_property("data", data, is_complex=True)
         self.register_optics_property(
             "wavelength", wavelength_or_default(wavelength), is_scalar=True, is_positive=True
-        )
-
-        self.propagation_method = propagation_method
-        self.asm_pad_factor = asm_pad_factor  # type: ignore[assignment]
-        self.interpolation_mode = interpolation_mode
-
-    @property
-    def propagation_method(self) -> str:
-        """Returns the propagation method."""
-        return self._propagation_method
-
-    @propagation_method.setter
-    def propagation_method(self, value: str) -> None:
-        if not isinstance(value, str):
-            raise TypeError(f"Expected propagation_method to be a string, but got {type(value).__name__}.")
-        if value.upper() not in VALID_PROPAGATION_METHODS:
-            raise ValueError(
-                f"Expected propagation_method to be one of {VALID_PROPAGATION_METHODS}, but got {value}."
-            )
-        self._propagation_method = value.upper()
-
-    @property
-    def asm_pad_factor(self) -> tuple:
-        """Returns the padding factor for angular spectrum method (ASM) propagation."""
-        return self._asm_pad_factor
-
-    @asm_pad_factor.setter
-    def asm_pad_factor(self, value: Vector2) -> None:
-        tensor = initialize_tensor(
-            "asm_pad_factor", value, is_vector2=True, is_integer=True, is_non_negative=True
-        )
-        self._asm_pad_factor = (tensor[0].item(), tensor[1].item())
-
-    @property
-    def interpolation_mode(self) -> str:
-        """Returns the interpolation mode."""
-        return self._interpolation_mode
-
-    @interpolation_mode.setter
-    def interpolation_mode(self, value: str) -> None:
-        if not isinstance(value, str):
-            raise TypeError(f"Expected interpolation_mode to be a string, but got {type(value).__name__}.")
-        if value.lower() not in VALID_INTERPOLATION_MODES:
-            raise ValueError(
-                f"Expected interpolation_mode to be one of {VALID_INTERPOLATION_MODES}, but got {value}."
-            )
-        self._interpolation_mode = value.lower()
-
-    def extra_repr(self) -> str:
-        return (
-            super().extra_repr()
-            + f", propagation_method={self.propagation_method}"
-            + f", asm_pad_factor=({self.asm_pad_factor[0]}, {self.asm_pad_factor[1]})"
-            + f", interpolation_mode={self.interpolation_mode})"
         )
 
     def intensity(self) -> Tensor:
@@ -134,6 +72,9 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
         z: Scalar,
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
+        propagation_method: str = "AUTO",
+        asm_pad_factor: Vector2 = 2,
+        interpolation_mode: str = "nearest",
     ) -> Field:
         """
         Propagates the field through free-space to a plane defined by the input parameters.
@@ -145,13 +86,20 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
             spacing (Optional[Vector2]): Distance between grid points along planar dimensions. Default:
                 if `None`, uses a global default (see :meth:`torchoptics.set_default_spacing()`).
             offset (Optional[Vector2]): Center coordinates of the plane. Default: `(0, 0)`.
+            propagation_method (str): The propagation method to use. Default: `"AUTO"`.
+            asm_pad_factor (Vector2): The padding factor along both planar dimensions for ASM propagation.
+                Default: `2`.
+            interpolation_mode (str): The interpolation mode to use. Default: `"nearest"`.
+
 
         Returns:
             Field: Output field after propagating to the plane.
         """
-        return propagator(self, shape, z, spacing, offset)
+        return propagator(
+            self, shape, z, spacing, offset, propagation_method, asm_pad_factor, interpolation_mode
+        )
 
-    def propagate_to_z(self, z: Scalar) -> Field:
+    def propagate_to_z(self, z: Scalar, **prop_kwargs) -> Field:
         """
         Propagates the field through free-space to a plane at a specific z position.
 
@@ -160,20 +108,30 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
         Args:
             field (Field): Input field.
             z (Scalar): Position along the z-axis.
+            propagation_method (str): The propagation method to use. Default: `"AUTO"`.
+            asm_pad_factor (Vector2): The padding factor along both planar dimensions for ASM propagation.
+                Default: `2`.
+            interpolation_mode (str): The interpolation mode to use. Default: `"nearest"`.
+
 
         Returns:
             Field: Output field after propagating to the plane.
         """
 
-        return self.propagate(self.shape, z, self.spacing, self.offset)
+        return self.propagate(self.shape, z, self.spacing, self.offset, **prop_kwargs)
 
-    def propagate_to_plane(self, plane: PlanarGeometry) -> Field:
+    def propagate_to_plane(self, plane: PlanarGeometry, **prop_kwargs) -> Field:
         """
         Propagates the field through free-space to a plane defined by a :class:`PlanarGeometry` object.
 
         Args:
             field (Field): Input field.
             plane (PlanarGeometry): Plane geometry.
+            propagation_method (str): The propagation method to use. Default: `"AUTO"`.
+            asm_pad_factor (Vector2): The padding factor along both planar dimensions for ASM propagation.
+                Default: `2`.
+            interpolation_mode (str): The interpolation mode to use. Default: `"nearest"`.
+
 
         Returns:
             Field: Output field after propagating to the plane.
@@ -181,7 +139,7 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
 
         if not isinstance(plane, PlanarGeometry):
             raise TypeError(f"Expected plane to be a PlanarGeometry, but got {type(plane).__name__}.")
-        return self.propagate(plane.shape, plane.z, plane.spacing, plane.offset)
+        return self.propagate(plane.shape, plane.z, plane.spacing, plane.offset, **prop_kwargs)
 
     def modulate(self, modulation_profile: Tensor) -> Field:
         """
@@ -272,9 +230,6 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
             "z": self.z,
             "spacing": self.spacing,
             "offset": self.offset,
-            "propagation_method": self.propagation_method,
-            "asm_pad_factor": self.asm_pad_factor,
-            "interpolation_mode": self.interpolation_mode,
         }
         properties.update(kwargs)
         return self.__class__(**properties)  # type: ignore[arg-type]
@@ -300,10 +255,6 @@ class PolarizedField(Field):  # pylint: disable=abstract-method
         spacing (Optional[Vector2]): Distance between grid points along planar dimensions. Default: if
             `None`, uses a global default (see :meth:`torchoptics.set_default_spacing()`).
         offset (Optional[Vector2]): Center coordinates of the plane. Default: `(0, 0)`.
-        propagation_method (str): The propagation method to use. Default: `"AUTO"`.
-        asm_pad_factor (Vector2): The padding factor along planar dimensions for angular spectrum method (ASM)
-            propagation. Default: `2`.
-        interpolation_mode (str): The interpolation mode to use. Default: `"nearest"`.
     """
 
     _data_min_dim = 3
@@ -357,10 +308,6 @@ class CoherenceField(Field):  # pylint: disable=abstract-method
         spacing (Optional[Vector2]): Distance between grid points along planar dimensions. Default: if
             `None`, uses a global default (see :meth:`torchoptics.set_default_spacing()`).
         offset (Optional[Vector2]): Center coordinates of the plane. Default: `(0, 0)`.
-        propagation_method (str): The propagation method to use. Default: `"AUTO"`.
-        asm_pad_factor (Vector2): The padding factor along planar dimensions for angular spectrum method (ASM)
-            propagation. Default: `2`.
-        interpolation_mode (str): The interpolation mode to use. Default: `"nearest"`.
     """
 
     _data_min_dim = 4
@@ -378,12 +325,21 @@ class CoherenceField(Field):  # pylint: disable=abstract-method
         z: Scalar,
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
+        propagation_method: str = "AUTO",
+        asm_pad_factor: Vector2 = 2,
+        interpolation_mode: str = "nearest",
     ) -> Field:
         def adjoint(data: Tensor):
             return data.conj().transpose(-1, -3).transpose(-2, -4)
 
         def prop(data: Tensor, output_plane_geometry: dict):
-            return propagator(self.copy(data=data), **output_plane_geometry).data
+            return propagator(
+                self.copy(data=data),
+                **output_plane_geometry,
+                propagation_method=propagation_method,
+                asm_pad_factor=asm_pad_factor,
+                interpolation_mode=interpolation_mode,
+            ).data
 
         # Define the geometry of the output plane for propagation.
         output_geometry = PlanarGeometry(shape, z, spacing, offset).geometry

--- a/torchoptics/propagation/__init__.py
+++ b/torchoptics/propagation/__init__.py
@@ -1,11 +1,10 @@
 """This module defines functions for field propagation."""
 
 from .propagator import (
-    calculate_min_dim_propagation_distance,
+    VALID_INTERPOLATION_MODES,
+    VALID_PROPAGATION_METHODS,
+    calculate_critical_propagation_distance,
     get_propagation_plane,
-    is_dim_propagation,
+    is_asm,
     propagator,
 )
-
-VALID_PROPAGATION_METHODS = {"AUTO", "AUTO_FRESNEL", "ASM", "ASM_FRESNEL", "DIM", "DIM_FRESNEL"}
-VALID_INTERPOLATION_MODES = {"none", "bilinear", "bicubic", "nearest"}

--- a/torchoptics/propagation/angular_spectrum_method.py
+++ b/torchoptics/propagation/angular_spectrum_method.py
@@ -11,6 +11,8 @@ from torch.nn.functional import pad
 
 from ..functional import fftfreq_grad
 from ..planar_geometry import PlanarGeometry
+from ..type_defs import Vector2
+from ..utils import initialize_tensor
 
 if TYPE_CHECKING:
     from ..fields import Field
@@ -18,7 +20,9 @@ if TYPE_CHECKING:
 __all__ = ["asm_propagation"]
 
 
-def asm_propagation(field: Field, propagation_plane: PlanarGeometry) -> Field:
+def asm_propagation(
+    field: Field, propagation_plane: PlanarGeometry, propagation_method: str, asm_pad_factor: Vector2
+) -> Field:
     """
     Propagates the field to a plane using the angular spectrum method (ASM).
 
@@ -29,35 +33,42 @@ def asm_propagation(field: Field, propagation_plane: PlanarGeometry) -> Field:
     Returns:
         Field: Output field after propagation.
     """
+    asm_pad_factor = initialize_tensor(
+        "asm_pad_factor", asm_pad_factor, is_vector2=True, is_integer=True, is_non_negative=True
+    )
     propagation_distance = propagation_plane.z - field.z
-    transfer_function = calculate_transfer_function(field, propagation_distance)
-    propagated_data = apply_transfer_function(transfer_function, field)
+    transfer_function = calculate_transfer_function(
+        field, propagation_distance, asm_pad_factor, propagation_method
+    )
+    propagated_data = apply_transfer_function(transfer_function, field, asm_pad_factor)
     propagated_field = field.copy(data=propagated_data, z=propagation_plane.z)
-    validate_bounds(propagated_field, propagation_plane)
+    validate_bounds(propagated_field, propagation_plane, asm_pad_factor)
     return propagated_field
 
 
-def calculate_transfer_function(field: Field, propagation_distance: Tensor) -> Tensor:
+def calculate_transfer_function(
+    field: Field, propagation_distance: Tensor, asm_pad_factor: Tensor, propagation_method: str
+) -> Tensor:
     """Calculate the transfer function for ASM propagation."""
     # pylint: disable=not-callable
-    padded_input_shape = torch.tensor(field.shape) * (2 * torch.tensor(field.asm_pad_factor) + 1)
+    padded_input_shape = torch.tensor(field.shape) * (2 * asm_pad_factor + 1)
     freq_x, freq_y = (fftshift(fftfreq_grad(n, d)) for n, d in zip(padded_input_shape, field.spacing))
     kx, ky = torch.meshgrid(freq_x * 2 * torch.pi, freq_y * 2 * torch.pi, indexing="ij")
     k = (2 * torch.pi) / field.wavelength
     kz = torch.sqrt(k**2 - kx**2 - ky**2)
     if torch.any(torch.isnan(kz)):
         raise ValueError("NaNs in kz")
-    if field.propagation_method in {"ASM_FRESNEL", "AUTO_FRESNEL"}:
+    if propagation_method in {"ASM_FRESNEL", "AUTO_FRESNEL"}:
         return torch.exp(1j * k * propagation_distance) * torch.exp(
             -1j * field.wavelength * propagation_distance * (kx**2 + ky**2) / (4 * torch.pi)
         )
     return torch.exp(1j * kz * propagation_distance)  # ASM using RS equation
 
 
-def apply_transfer_function(transfer_function: Tensor, field: Field) -> Tensor:
+def apply_transfer_function(transfer_function: Tensor, field: Field, asm_pad_factor: Tensor) -> Tensor:
     """Apply the transfer function to the field for ASM propagation."""
     # pylint: disable=not-callable
-    pad_x, pad_y = [field.asm_pad_factor[i] * field.shape[i] for i in range(2)]
+    pad_x, pad_y = [int(asm_pad_factor[i] * field.shape[i]) for i in range(2)]
     data = pad(field.data, (pad_y, pad_y, pad_x, pad_x), mode="constant", value=0)
     data = fftshift(fft2(data))
     data = data * transfer_function
@@ -65,7 +76,7 @@ def apply_transfer_function(transfer_function: Tensor, field: Field) -> Tensor:
     return data
 
 
-def validate_bounds(propagated_field: Field, target_plane: PlanarGeometry) -> None:
+def validate_bounds(propagated_field: Field, target_plane: PlanarGeometry, asm_pad_factor: Vector2) -> None:
     """Validate that the propagated field bounds contain the target plane bounds."""
     target_plane_bounds = target_plane.bounds(use_grid_points=True)
     propagated_field_bounds = propagated_field.bounds(use_grid_points=True)
@@ -81,6 +92,6 @@ def validate_bounds(propagated_field: Field, target_plane: PlanarGeometry) -> No
 
         raise ValueError(
             f"Propagation plane bounds {formatted_target_bounds} are outside padded field bounds "
-            f"{formatted_propagated_bounds}.\nIncrease asm_pad_factor ({propagated_field.asm_pad_factor}) "
+            f"{formatted_propagated_bounds}.\nIncrease asm_pad_factor ({asm_pad_factor}) "
             f"or adjust propagation plane offset ({formatted_target_offset})."
         )

--- a/torchoptics/propagation/direct_integration_method.py
+++ b/torchoptics/propagation/direct_integration_method.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = ["dim_propagation"]
 
 
-def dim_propagation(field: Field, propagation_plane: PlanarGeometry) -> Field:
+def dim_propagation(field: Field, propagation_plane: PlanarGeometry, propagation_method: str) -> Field:
     """
     Propagates the field to a plane using the direct integration method (DIM).
 
@@ -28,35 +28,42 @@ def dim_propagation(field: Field, propagation_plane: PlanarGeometry) -> Field:
         Field: Output field after propagation.
     """
     x, y = calculate_meshgrid(field, propagation_plane)
-    impulse_response = calculate_impulse_response(field, propagation_plane, x, y)
+    impulse_response = calculate_impulse_response(field, propagation_plane, x, y, propagation_method)
     propagated_data = conv2d_fft(impulse_response, field.data)
     return field.copy(data=propagated_data, z=propagation_plane.z, offset=propagation_plane.offset)
 
 
 def calculate_meshgrid(field: Field, propagation_plane: PlanarGeometry) -> tuple[Tensor, Tensor]:
     """Calculate the meshgrid for the impulse response calculation."""
-    field_bounds = field.bounds(use_grid_points=True)
-    propagation_plane_bounds = propagation_plane.bounds(use_grid_points=True)
-
-    grid_bounds = [
-        propagation_plane_bounds[0] - field_bounds[1],
-        propagation_plane_bounds[1] - field_bounds[0],
-        propagation_plane_bounds[2] - field_bounds[3],
-        propagation_plane_bounds[3] - field_bounds[2],
-    ]
+    grid_bounds = calculate_grid_bounds(field, propagation_plane)
     grid_shape = [field.shape[i] + propagation_plane.shape[i] - 1 for i in range(2)]
     return meshgrid2d(grid_bounds, grid_shape)
 
 
+def calculate_grid_bounds(field: Field, propagation_plane: PlanarGeometry) -> Tensor:
+    """Calculate the grid bounds for the impulse response calculation."""
+    field_bounds = field.bounds(use_grid_points=True)
+    propagation_plane_bounds = propagation_plane.bounds(use_grid_points=True)
+
+    return torch.stack(
+        [
+            propagation_plane_bounds[0] - field_bounds[1],
+            propagation_plane_bounds[1] - field_bounds[0],
+            propagation_plane_bounds[2] - field_bounds[3],
+            propagation_plane_bounds[3] - field_bounds[2],
+        ]
+    )
+
+
 def calculate_impulse_response(
-    field: Field, propagation_plane: PlanarGeometry, x: Tensor, y: Tensor
+    field: Field, propagation_plane: PlanarGeometry, x: Tensor, y: Tensor, propagation_method: str
 ) -> Tensor:
     """Calculate the impulse response for DIM propagation."""
     propagation_distance = propagation_plane.z - field.z
     r_squared = x**2 + y**2 + propagation_distance**2
     r = torch.sqrt(r_squared) if propagation_distance >= 0 else -torch.sqrt(r_squared)
     k = 2 * torch.pi / field.wavelength
-    if field.propagation_method in {"DIM_FRESNEL", "AUTO_FRESNEL"}:
+    if propagation_method in {"DIM_FRESNEL", "AUTO_FRESNEL"}:
         impulse_response = (
             (torch.exp(1j * k * propagation_distance) / (1j * field.wavelength * propagation_distance))
             * torch.exp(1j * k / (2 * propagation_distance) * (x**2 + y**2))


### PR DESCRIPTION
Refactored propagation logic in `Field` and related functions.

- Removed `propagation_method`, `asm_pad_factor`, and `interpolation_mode` parameters from the `Field` class initialization, and related properties and methods. These parameters are now passed directly to the `propagate()`  methods in `Field` and `measure()` methods in `System`, which are used by `propagator()`.
 -  Updated the logic for the `auto` propagation method in `calculate_critical_propagation_distance()` accounting for offset between field and propagation plane. 