### PR TITLE
Allow evanescent waves in asm propagation

### DIFF
--- a/torchoptics/propagation/angular_spectrum_method.py
+++ b/torchoptics/propagation/angular_spectrum_method.py
@@ -57,8 +57,6 @@ def calculate_transfer_function(
     k = (2 * torch.pi) / field.wavelength
     kz_squared = (k**2 - kx**2 - ky**2).to(torch.cdouble)  # Ensure kz_squared is complex for sqrt calculation
     kz = torch.sqrt(kz_squared)  # kz is imaginary for evanescent waves where kz^2 < 0
-    if torch.any(torch.isnan(kz)):
-        raise ValueError("NaNs in kz")
     if propagation_method in {"ASM_FRESNEL", "AUTO_FRESNEL"}:
         return torch.exp(1j * k * propagation_distance) * torch.exp(
             -1j * field.wavelength * propagation_distance * (kx**2 + ky**2) / (4 * torch.pi)

--- a/torchoptics/propagation/angular_spectrum_method.py
+++ b/torchoptics/propagation/angular_spectrum_method.py
@@ -55,7 +55,8 @@ def calculate_transfer_function(
     freq_x, freq_y = (fftshift(fftfreq_grad(n, d)) for n, d in zip(padded_input_shape, field.spacing))
     kx, ky = torch.meshgrid(freq_x * 2 * torch.pi, freq_y * 2 * torch.pi, indexing="ij")
     k = (2 * torch.pi) / field.wavelength
-    kz = torch.sqrt(k**2 - kx**2 - ky**2)
+    kz_squared = (k**2 - kx**2 - ky**2).to(torch.cdouble)  # Ensure kz_squared is complex for sqrt calculation
+    kz = torch.sqrt(kz_squared)  # kz is imaginary for evanescent waves where kz^2 < 0
     if torch.any(torch.isnan(kz)):
         raise ValueError("NaNs in kz")
     if propagation_method in {"ASM_FRESNEL", "AUTO_FRESNEL"}:

--- a/torchoptics/propagation/angular_spectrum_method.py
+++ b/torchoptics/propagation/angular_spectrum_method.py
@@ -54,9 +54,10 @@ def calculate_transfer_function(
     padded_input_shape = torch.tensor(field.shape) * (2 * asm_pad_factor + 1)
     freq_x, freq_y = (fftshift(fftfreq_grad(n, d)) for n, d in zip(padded_input_shape, field.spacing))
     kx, ky = torch.meshgrid(freq_x * 2 * torch.pi, freq_y * 2 * torch.pi, indexing="ij")
-    k = (2 * torch.pi) / field.wavelength
+    k = 2 * torch.pi / field.wavelength
     kz_squared = (k**2 - kx**2 - ky**2).to(torch.cdouble)  # Ensure kz_squared is complex for sqrt calculation
     kz = torch.sqrt(kz_squared)  # kz is imaginary for evanescent waves where kz^2 < 0
+
     if propagation_method in {"ASM_FRESNEL", "AUTO_FRESNEL"}:
         return torch.exp(1j * k * propagation_distance) * torch.exp(
             -1j * field.wavelength * propagation_distance * (kx**2 + ky**2) / (4 * torch.pi)

--- a/torchoptics/propagation/direct_integration_method.py
+++ b/torchoptics/propagation/direct_integration_method.py
@@ -64,14 +64,13 @@ def calculate_impulse_response(
     r_squared = x**2 + y**2 + propagation_distance**2
     r = torch.sqrt(r_squared) if propagation_distance >= 0 else -torch.sqrt(r_squared)
     k = 2 * torch.pi / field.wavelength
+
     if propagation_method in {"DIM_FRESNEL", "AUTO_FRESNEL"}:
-        impulse_response = (
+        return (
             (torch.exp(1j * k * propagation_distance) / (1j * field.wavelength * propagation_distance))
             * torch.exp(1j * k / (2 * propagation_distance) * (x**2 + y**2))
             * field.cell_area()
         )
-    else:  # DIM using RS equation
-        impulse_response = (
-            1 / (2 * torch.pi) * (1 / r - 1j * k) * torch.exp(1j * k * r) * propagation_distance / r_squared
-        ) * field.cell_area()
-    return impulse_response
+    return (  # DIM using RS equation
+        1 / (2 * torch.pi) * (1 / r - 1j * k) * torch.exp(1j * k * r) * propagation_distance / r_squared
+    ) * field.cell_area()


### PR DESCRIPTION
Removes the error previously raised for imaginary-valued `k_z` caused by evanescent waves. Now, the evanescent waves decay exponentially. 