### PR TITLE
Add type hints and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,21 @@ Access the latest documentation at [torchoptics.readthedocs.io](https://torchopt
 
 ## Installation
 
-The latest stable release of TorchOptics is available on [PyPI](https://pypi.org/project/torchoptics/) and can
-be installed with:
+To install the latest **stable release** of TorchOptics from [PyPI](https://pypi.org/project/torchoptics/), run:
 
 ```sh
 pip install torchoptics
 ```
 
-The latest development version can be installed from [GitHub](https://github.com/MatthewFilipovich/torchoptics):
+For the latest **development version**, install directly from [GitHub](https://github.com/MatthewFilipovich/torchoptics):
 
 ```sh
 git clone https://github.com/MatthewFilipovich/torchoptics
 cd torchoptics
-pip install -e .
+pip install -e '.[dev]'
 ```
+
+This installs the library in editable mode, along with additional dependencies for development and testing.
 
 ## Usage
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,20 +60,23 @@ Key Features
 Installation
 ------------
 
-The latest stable release of TorchOptics is available on `PyPI <https://pypi.org/project/torchoptics>`_
-and can be installed with:
+To install the latest **stable release** of TorchOptics from `PyPI <https://pypi.org/project/torchoptics>`_ , run:
 
 .. code-block:: bash
 
     pip install torchoptics
 
-The latest development version can be installed from `GitHub <https://github.com/MatthewFilipovich/torchoptics>`_:
+For the latest **development version**, install directly from `GitHub <https://github.com/MatthewFilipovich/torchoptics>`_:
+
 
 .. code-block:: bash
 
     git clone https://github.com/MatthewFilipovich/torchoptics
     cd torchoptics
-    pip install -e .
+    pip install -e '.[dev]'
+
+This installs the library in editable mode, along with additional dependencies for development and testing.
+
 
 Contributing
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ Homepage = "https://github.com/MatthewFilipovich/torchoptics"
 Documentation = "https://torchoptics.readthedocs.io/"
 Tracker = "https://github.com/MatthewFilipovich/torchoptics/issues"
 
+[tool.setuptools.package-data]
+"torchoptics" = ["py.typed"]
+
 [tool.black]
 line-length = 110
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -397,3 +397,23 @@ class TestSpatialCoherence(unittest.TestCase):
     def test_visualization(self):
         fig = self.spatial_coherence.visualize(return_fig=True, show=False)
         self.assertIsInstance(fig, plt.Figure)
+
+    def test_raise_error(self):
+        self.shape = (20, 21)
+        self.wavelength = 795e-9
+        self.z = 0
+        self.spacing = 9.2e-6
+        self.offset = (-102e-6, 83e-6)
+        self.input_field = torch.rand(self.shape, dtype=torch.double) * torch.exp(
+            2j * torch.pi * torch.rand(self.shape, dtype=torch.double)
+        )
+        self.input_spatial_coherence = outer2d(self.input_field, self.input_field)
+
+        # Make the input_spatial_coherence non-Hermitian
+        self.input_spatial_coherence[0, 3] = self.input_spatial_coherence[3, 0] + 2
+
+        self.spatial_coherence = CoherenceField(
+            self.input_spatial_coherence, self.wavelength, self.z, self.spacing, self.offset
+        )
+        with self.assertRaises(ValueError):
+            self.spatial_coherence.intensity()

--- a/torchoptics/__init__.py
+++ b/torchoptics/__init__.py
@@ -1,4 +1,4 @@
-"""This is the top-level module for the torchoptics package."""
+"""TorchOptics is an open-source Python library for differentiable wave optics simulations with PyTorch."""
 
 import torchoptics.elements
 import torchoptics.functional

--- a/torchoptics/type_defs.py
+++ b/torchoptics/type_defs.py
@@ -3,9 +3,10 @@
 from typing import Sequence, Union
 
 from torch import Tensor
+from typing_extensions import TypeAlias
 
 __all__ = ["Scalar", "Vector2"]
 
-Int = Union[int, Tensor]
-Scalar = Union[int, float, Tensor]
-Vector2 = Union[int, float, Tensor, Sequence]
+Int: TypeAlias = Union[int, Tensor]
+Scalar: TypeAlias = Union[int, float, Tensor]
+Vector2: TypeAlias = Union[int, float, Tensor, Sequence]


### PR DESCRIPTION
Added type hints support with a `py.typed` file and utilize `TypeAlias` for type definitions. Update installation instructions in the README and index.rst for clarity and include a more descriptive module docstring.