### PR TITLE
Refactor `Field` class and subclasses

### DIFF
--- a/docs/source/examples/polarized_field.py
+++ b/docs/source/examples/polarized_field.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import torch
 
 import torchoptics
-from torchoptics import PolarizedField
+from torchoptics import Field
 from torchoptics.elements import LinearPolarizer
 
 # %%
@@ -28,17 +28,22 @@ torchoptics.set_default_wavelength(700e-9)
 # %%
 # Initializing a Polarized Field
 # ------------------------------
-# We create a uniformly polarized field along the :math:`x`-axis.
+# In TorchOptics, polarized light is represented using a tensor with at least three dimensions.
+# The last two dimensions correspond to the spatial wavefront, while the third-to-last
+# dimension represents the polarization components (x, y, and z).
+#
+# Here, we initialize a uniformly polarized field where the polarization is entirely
+# along the :math:`x`-axis, meaning only the first component of the polarization vector is nonzero.
 
-field_data = torch.zeros(3, shape, shape)
-field_data[0, :, :] = 1  # Polarization along the x-axis
-field = PolarizedField(field_data).normalize()
+field_data = torch.zeros(3, shape, shape)  # Shape: (polarization, height, width)
+field_data[0] = 1  # Set x-polarization to 1, y and z components remain zero
 
+field = Field(field_data).normalize()
 # %%
 # Malus’s Law: Power Transmission Through a Rotating Polarizer
 # ------------------------------------------------------------
 # We apply linear polarizers at different angles ranging from 0 to :math:`2\pi` radians.
-# `Malus’s law  <https://en.wikipedia.org/wiki/Polarizer#Malus's_law_and_other_properties>`_ states that the 
+# `Malus’s law  <https://en.wikipedia.org/wiki/Polarizer#Malus's_law_and_other_properties>`_ states that the
 # transmitted power follows:
 #
 # .. math::
@@ -48,7 +53,7 @@ field = PolarizedField(field_data).normalize()
 # initial polarization and the polarizer’s axis.
 
 angles = torch.linspace(0, 2 * torch.pi, 400)
-field_power = [LinearPolarizer(shape, theta=theta)(field).power() for theta in angles]
+field_power = [LinearPolarizer(shape, theta=theta)(field).power().sum() for theta in angles]
 
 # Plot results
 plt.plot(angles, field_power)
@@ -73,19 +78,19 @@ plt.show()
 # - However, inserting an intermediate 45° polarizer allows some light to pass through.
 # - The second polarizer (90°) then transmits part of this newly polarized light.
 #
-# The first polarizer projects the field onto a new axis, enabling partial transmission through the second 
+# The first polarizer projects the field onto a new axis, enabling partial transmission through the second
 # polarizer.
 
 polarizer_0 = LinearPolarizer(shape, theta=0)
 polarizer_45 = LinearPolarizer(shape, theta=torch.pi / 4)
 polarizer_90 = LinearPolarizer(shape, theta=torch.pi / 2)
 
-# Compute power measurements
-initial_power = field.power()
-power_after_0 = polarizer_0(field).power()
-power_after_45 = polarizer_45(field).power()
-power_after_90 = polarizer_90(field).power()
-power_after_45_90 = polarizer_90(polarizer_45(field)).power()
+# Compute total power measurements
+initial_power = field.power().sum()
+power_after_0 = polarizer_0(field).power().sum()
+power_after_45 = polarizer_45(field).power().sum()
+power_after_90 = polarizer_90(field).power().sum()
+power_after_45_90 = polarizer_90(polarizer_45(field)).power().sum()
 
 # Print results
 print(f"Initial Power: {initial_power:.2f}")

--- a/docs/source/examples/spatial_coherence.py
+++ b/docs/source/examples/spatial_coherence.py
@@ -10,7 +10,7 @@ Simulates Gaussian beams with low and high spatial coherence.
 import torch
 
 import torchoptics
-from torchoptics import CoherenceField
+from torchoptics import SpatialCoherence
 from torchoptics.profiles import gaussian_schell_model as gsm
 
 # Set simulation properties
@@ -30,9 +30,9 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 torchoptics.set_default_spacing(spacing)
 torchoptics.set_default_wavelength(wavelength)
 
-# Initialize coherence fields
-low_coherence_field = CoherenceField(gsm(shape, waist_radius, low_coherence_width)).to(device)
-high_coherence_field = CoherenceField(gsm(shape, waist_radius, high_coherence_width)).to(device)
+# Initialize spatial coherence fields
+low_spatial_coherence = SpatialCoherence(gsm(shape, waist_radius, low_coherence_width)).to(device)
+high_spatial_coherence = SpatialCoherence(gsm(shape, waist_radius, high_coherence_width)).to(device)
 
 # %%
 # Propagation of Low and High Coherence Fields
@@ -44,5 +44,5 @@ high_coherence_field = CoherenceField(gsm(shape, waist_radius, high_coherence_wi
 propagation_distances = [0, 0.01, 0.02]
 
 for z in propagation_distances:
-    low_coherence_field.propagate_to_z(z).visualize(title=f"Low Coherence Field at z = {z} m", vmin=0)
-    high_coherence_field.propagate_to_z(z).visualize(title=f"High Coherence Field at z = {z} m", vmin=0)
+    low_spatial_coherence.propagate_to_z(z).visualize(title=f"Low Coherence Field at z = {z} m", vmin=0)
+    high_spatial_coherence.propagate_to_z(z).visualize(title=f"High Coherence Field at z = {z} m", vmin=0)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -70,7 +70,7 @@ class TestPolarizingBeamSplitters(unittest.TestCase):
         self.assertTrue(torch.allclose(bs_field1.data[:, 1], field.data[:, 1]))
 
         # Test with z-polarized field
-        field = Field(torch.ones(4, 3, shape, shape), wavelength=700e-9, spacing=1e-5)
+        field = Field(torch.ones(1, 2, shape, shape), wavelength=700e-9, spacing=1e-5)
         with self.assertRaises(ValueError):
             bs.forward(field)
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -76,33 +76,9 @@ class TestPolarizingBeamSplitters(unittest.TestCase):
 
 
 class TestDetectors(unittest.TestCase):
-    def test_hermite_gaussian_orthogonality(self):
-        """
-        Test that the FieldDetector correctly identifies orthogonality of Hermite-Gaussian modes.
-        For two different Hermite-Gaussian modes, the inner product should be 0.
-        For the same mode, the inner product should be 1.
-        """
-        shape = (100, 100)  # Grid dimensions
-        spacing = (0.1, 0.1)  # Grid spacing
-        radius = 1.0  # Radius of the aperture
 
-        # Assuming you have a function to generate Hermite-Gaussian modes
-        hg_00 = hermite_gaussian(shape, 0, 0, radius, spacing=spacing)
-        hg_10 = hermite_gaussian(shape, 1, 0, radius, spacing=spacing)
-        hg_01 = hermite_gaussian(shape, 0, 1, radius, spacing=spacing)
-        hg_modes = torch.stack([hg_00, hg_10, hg_01])
-
-        # Create FieldDetector with field_1 as the weight
-        field_01 = Field(hg_01, wavelength=1, spacing=spacing)
-        detector = FieldDetector(weight=hg_modes, spacing=spacing)
-
-        output = detector(field_01)
-        self.assertIsInstance(output, torch.Tensor)
-        # The inner product of the same mode should be 1 and different modes should be 0
-        self.assertTrue(torch.allclose(output, torch.tensor((0.0, 0.0, 1.0), dtype=torch.double)))
-
-    def test_intensity_detector(self):
-        """Test the IntensityDetector class."""
+    def test_linear_detector(self):
+        """Test the LinearDetector class."""
         shape = (100, 100)
         spacing = 1
         field = Field(torch.ones(*shape), wavelength=700e-9, spacing=spacing)
@@ -110,7 +86,7 @@ class TestDetectors(unittest.TestCase):
         weight[0, :50, :60] = 1
         weight[1, :40, :30] = 1
 
-        detector = IntensityDetector(weight, spacing=spacing)
+        detector = LinearDetector(weight, spacing=spacing)
         output = detector(field)
         self.assertIsInstance(output, torch.Tensor)
         self.assertTrue(output.shape == (2,))
@@ -119,9 +95,9 @@ class TestDetectors(unittest.TestCase):
         self.assertIsInstance(fig, plt.Figure)
 
         with self.assertRaises(TypeError):
-            IntensityDetector("not a tensor", spacing=spacing)
+            LinearDetector("not a tensor", spacing=spacing)
         with self.assertRaises(ValueError):
-            IntensityDetector(torch.rand(1, 2, 3, 4), spacing=spacing)
+            LinearDetector(torch.rand(1, 2, 3, 4), spacing=spacing)
 
 
 class TestModulatorClasses(unittest.TestCase):

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import torch
 
 import torchoptics
-from torchoptics import Field, PolarizedField
+from torchoptics import Field
 from torchoptics.elements import *
 from torchoptics.profiles import hermite_gaussian
 
@@ -33,20 +33,18 @@ class TestBeamSplitters(unittest.TestCase):
         self.assertTrue(torch.allclose(bs_field0.intensity(), 2 * field.intensity()))
         self.assertTrue(torch.allclose(bs_field1.intensity(), 0 * field.intensity()))
 
-        polarized_field = torchoptics.PolarizedField(
-            torch.ones(4, 3, shape, shape), wavelength=700e-9, spacing=1e-5
-        )
+        polarized_field = torchoptics.Field(torch.ones(4, 3, shape, shape), wavelength=700e-9, spacing=1e-5)
 
         # Send a single polarized field through the beam splitter
         bs_polarized_field0, bs_polarized_field1 = bs.forward(polarized_field)
-        self.assertIsInstance(bs_polarized_field0, torchoptics.PolarizedField)
-        self.assertIsInstance(bs_polarized_field1, torchoptics.PolarizedField)
+        self.assertIsInstance(bs_polarized_field0, torchoptics.Field)
+        self.assertIsInstance(bs_polarized_field1, torchoptics.Field)
         self.assertTrue(torch.allclose(bs_polarized_field0.intensity(), 0.5 * polarized_field.intensity()))
         self.assertTrue(torch.allclose(bs_polarized_field1.intensity(), 0.5 * polarized_field.intensity()))
         # Send two polarized fields through the beam splitter
         bs_polarized_field0, bs_polarized_field1 = bs.forward(polarized_field, polarized_field)
-        self.assertIsInstance(bs_polarized_field0, torchoptics.PolarizedField)
-        self.assertIsInstance(bs_polarized_field1, torchoptics.PolarizedField)
+        self.assertIsInstance(bs_polarized_field0, torchoptics.Field)
+        self.assertIsInstance(bs_polarized_field1, torchoptics.Field)
         self.assertTrue(torch.allclose(bs_polarized_field0.intensity(), 2 * polarized_field.intensity()))
         self.assertTrue(torch.allclose(bs_polarized_field1.intensity(), 0 * polarized_field.intensity()))
 
@@ -56,7 +54,7 @@ class TestPolarizingBeamSplitters(unittest.TestCase):
         """Test the PolarizingBeamSplitter class."""
         shape = 32
         z = 0
-        field = PolarizedField(torch.ones(4, 3, shape, shape), wavelength=700e-9, spacing=1e-5)
+        field = Field(torch.ones(4, 3, shape, shape), wavelength=700e-9, spacing=1e-5)
         field.data[:, 2] = 0  # z polarization
         # Create a 50:50 polarized beam splitter
         bs = PolarizingBeamSplitter(shape, z, spacing=1e-5)
@@ -64,15 +62,15 @@ class TestPolarizingBeamSplitters(unittest.TestCase):
 
         # Send a single polarized field through the beam splitter
         bs_field0, bs_field1 = bs.forward(field)
-        self.assertIsInstance(bs_field0, torchoptics.PolarizedField)
-        self.assertIsInstance(bs_field1, torchoptics.PolarizedField)
+        self.assertIsInstance(bs_field0, torchoptics.Field)
+        self.assertIsInstance(bs_field1, torchoptics.Field)
         self.assertTrue(torch.allclose(bs_field0.data[:, 0], field.data[:, 0]))
         self.assertTrue(torch.allclose(bs_field0.data[:, 1], 0 * field.data[:, 0]))
         self.assertTrue(torch.allclose(bs_field1.data[:, 0], 0 * field.data[:, 0]))
         self.assertTrue(torch.allclose(bs_field1.data[:, 1], field.data[:, 1]))
 
         # Test with z-polarized field
-        field = PolarizedField(torch.ones(4, 3, shape, shape), wavelength=700e-9, spacing=1e-5)
+        field = Field(torch.ones(4, 3, shape, shape), wavelength=700e-9, spacing=1e-5)
         with self.assertRaises(ValueError):
             bs.forward(field)
 
@@ -209,14 +207,12 @@ class TestPolarizedModulatorClasses(unittest.TestCase):
         self.phase_profile = torch.rand((3, 3, 10, 12))
         self.amplitude_profile = torch.rand((3, 3, 10, 12))
         self.z = 1.5
-        self.polarized_field = PolarizedField(
-            torch.ones(4, 3, 10, 12), wavelength=700e-9, z=self.z, spacing=1
-        )
+        self.polarized_field = Field(torch.ones(4, 3, 10, 12), wavelength=700e-9, z=self.z, spacing=1)
         torchoptics.set_default_spacing(1)
 
     def test_polarized_modulator_initialization(self):
         modulator = PolarizedModulator(self.polarized_modulation_profile, self.z)
-        self.assertIsInstance(modulator(self.polarized_field), PolarizedField)
+        self.assertIsInstance(modulator(self.polarized_field), Field)
         self.assertTrue(
             torch.equal(modulator.polarized_modulation_profile(), self.polarized_modulation_profile)
         )
@@ -225,13 +221,13 @@ class TestPolarizedModulatorClasses(unittest.TestCase):
         phase_modulator = PolarizedPhaseModulator(self.phase_profile, self.z)
         expected_profile = torch.exp(1j * self.phase_profile).to(dtype=torch.cdouble)
         self.assertTrue(torch.allclose(phase_modulator.polarized_modulation_profile(), expected_profile))
-        self.assertIsInstance(phase_modulator(self.polarized_field), PolarizedField)
+        self.assertIsInstance(phase_modulator(self.polarized_field), Field)
 
     def test_polarized_amplitude_modulator_initialization_and_profile(self):
         amplitude_modulator = PolarizedAmplitudeModulator(self.amplitude_profile, self.z)
         expected_profile = self.amplitude_profile.cdouble()
         self.assertTrue(torch.allclose(amplitude_modulator.polarized_modulation_profile(), expected_profile))
-        self.assertIsInstance(amplitude_modulator(self.polarized_field), PolarizedField)
+        self.assertIsInstance(amplitude_modulator(self.polarized_field), Field)
 
     def test_phase_modulation_profile_consistency(self):
         phase_modulator = PolarizedPhaseModulator(self.phase_profile, self.z)
@@ -293,9 +289,9 @@ class TestPolarizers(unittest.TestCase):
             .expand(2, 2, *shape)
         )
         self.assertTrue(torch.allclose(polarized_modulation_profile[:2, :2], expected_matrix))
-        field = PolarizedField(torch.ones(4, 3, *shape), wavelength=700e-9, spacing=spacing)
+        field = Field(torch.ones(4, 3, *shape), wavelength=700e-9, spacing=spacing)
         output_field = polarizer(field)
-        self.assertIsInstance(output_field, torchoptics.PolarizedField)
+        self.assertIsInstance(output_field, torchoptics.Field)
 
     def test_left_circular_polarizer(self):
         """Test the LeftCircularPolarizer class."""
@@ -311,9 +307,9 @@ class TestPolarizers(unittest.TestCase):
             .expand(2, 2, *shape)
         )
         self.assertTrue(torch.allclose(polarization_modulation_profile[:2, :2], expected_matrix))
-        field = PolarizedField(torch.ones(4, 3, *shape), wavelength=700e-9, spacing=spacing)
+        field = Field(torch.ones(4, 3, *shape), wavelength=700e-9, spacing=spacing)
         output_field = polarizer(field)
-        self.assertIsInstance(output_field, torchoptics.PolarizedField)
+        self.assertIsInstance(output_field, torchoptics.Field)
 
     def test_right_circular_polarizer(self):
         """Test the RightCircularPolarizer class."""
@@ -321,9 +317,9 @@ class TestPolarizers(unittest.TestCase):
         spacing = 1
         polarizer = RightCircularPolarizer(shape, spacing=spacing)
         self.assertEqual(polarizer.shape, shape)
-        field = PolarizedField(torch.ones(4, 3, *shape), wavelength=700e-9, spacing=spacing)
+        field = Field(torch.ones(4, 3, *shape), wavelength=700e-9, spacing=spacing)
         output_field = polarizer(field)
-        self.assertIsInstance(output_field, torchoptics.PolarizedField)
+        self.assertIsInstance(output_field, torchoptics.Field)
 
 
 class TestLens(unittest.TestCase):
@@ -354,9 +350,9 @@ class TestWaveplates(unittest.TestCase):
         theta = torch.tensor(torch.pi / 4)
         spacing = 1
         waveplate = Waveplate(shape, phi, theta, spacing=spacing)
-        field = PolarizedField(torch.ones(4, 3, *shape), wavelength=700e-9, spacing=spacing)
+        field = Field(torch.ones(4, 3, *shape), wavelength=700e-9, spacing=spacing)
         output_field = waveplate(field)
-        self.assertIsInstance(output_field, torchoptics.PolarizedField)
+        self.assertIsInstance(output_field, torchoptics.Field)
 
     def test_waveplate_modulation_profile(self):
         """Test the polarized matrix of the Waveplate with theta and phi set to 0."""

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -388,6 +388,25 @@ class TestSpatialCoherence(unittest.TestCase):
             self.input_spatial_coherence, self.wavelength, self.z, self.spacing, self.offset
         )
 
+    def test_incorrect_shape(self):
+        with self.assertRaises(ValueError):
+            SpatialCoherence(
+                torch.ones(2, 3),
+                wavelength=self.wavelength,
+                z=self.z,
+                spacing=self.spacing,
+                offset=self.offset,
+            )
+
+        with self.assertRaises(ValueError):
+            SpatialCoherence(
+                torch.ones(2, 3, 2, 5),  # Incorrect shape
+                wavelength=self.wavelength,
+                z=self.z,
+                spacing=self.spacing,
+                offset=self.offset,
+            ).intensity()
+
     def test_intensity_equal_field_coherent(self):
         self.assertTrue(torch.allclose(self.field.intensity(), self.spatial_coherence.intensity()))
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 from scipy.special import fresnel
 
-from torchoptics import CoherenceField, Field, PlanarGeometry
+from torchoptics import Field, PlanarGeometry, SpatialCoherence
 from torchoptics.elements import Modulator
 from torchoptics.functional import outer2d
 from torchoptics.propagation import VALID_PROPAGATION_METHODS
@@ -384,7 +384,7 @@ class TestSpatialCoherence(unittest.TestCase):
         )
         self.input_spatial_coherence = outer2d(self.input_field, self.input_field)
         self.field = Field(self.input_field, self.wavelength, self.z, self.spacing, self.offset)
-        self.spatial_coherence = CoherenceField(
+        self.spatial_coherence = SpatialCoherence(
             self.input_spatial_coherence, self.wavelength, self.z, self.spacing, self.offset
         )
 
@@ -442,7 +442,7 @@ class TestSpatialCoherence(unittest.TestCase):
         # Make the input_spatial_coherence non-Hermitian
         self.input_spatial_coherence[0, 3] = self.input_spatial_coherence[3, 0] + 2
 
-        self.spatial_coherence = CoherenceField(
+        self.spatial_coherence = SpatialCoherence(
             self.input_spatial_coherence, self.wavelength, self.z, self.spacing, self.offset
         )
         with self.assertRaises(ValueError):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -409,6 +409,7 @@ class TestSpatialCoherence(unittest.TestCase):
             prop_shape, prop_z, prop_spacing, prop_offset
         )
         self.assertTrue(torch.allclose(prop_field.intensity(), prop_spatial_coherence.intensity()))
+        self.assertTrue(prop_field.is_same_geometry(prop_spatial_coherence))
 
     def test_normalization_coherent(self):
         normalized_power = 2.53

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -335,34 +335,6 @@ class TestField(unittest.TestCase):
         fig = field.visualize(show=False, return_fig=True)
         self.assertIsInstance(fig, plt.Figure)
 
-
-class TestPolarizedField(unittest.TestCase):
-
-    def test_initialization(self):
-        shape = (10, 10)
-        data = torch.ones(3, *shape, dtype=torch.cdouble)
-        z = 5.0
-        spacing = 1.0
-        offset = None
-        wavelength = 0.3
-        pg = Field(data, wavelength, z, spacing, offset)
-
-        self.assertTrue(torch.equal(pg.data, torch.ones(3, *shape, dtype=torch.cdouble)))
-        self.assertTrue(torch.equal(pg.z, torch.tensor(5.0, dtype=torch.double)))
-        self.assertTrue(torch.equal(pg.spacing, torch.tensor([1.0, 1.0], dtype=torch.double)))
-        self.assertTrue(torch.equal(pg.offset, torch.tensor([0.0, 0.0], dtype=torch.double)))
-        self.assertTrue(torch.equal(pg.wavelength, torch.tensor(0.3, dtype=torch.double)))
-
-    def test_normalization(self):
-        field = Field(torch.rand(3, 10, 10), spacing=10e-6, wavelength=800e-9)
-        normalized_field = field.normalize(2)
-        self.assertTrue(torch.allclose(normalized_field.power(), torch.tensor(2, dtype=torch.double)))
-
-    def test_modulate(self):
-        field = Field(torch.ones(3, 10, 10), spacing=1, wavelength=1)
-        modulated_field = field.modulate(10 * torch.ones(10, 10))
-        self.assertTrue(torch.allclose(modulated_field.data, 10 * torch.ones(3, 10, 10, dtype=torch.cdouble)))
-
     def test_polarized_split(self):
         field = Field(torch.ones(3, 10, 10), spacing=1, wavelength=1)
         split_fields = field.polarized_split()
@@ -466,3 +438,12 @@ class TestSpatialCoherence(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             self.spatial_coherence.intensity()
+
+    def test_inner_outer(self):
+        spatial_coherence1 = SpatialCoherence(torch.ones(10, 10, 10, 10), spacing=1, wavelength=1)
+        spatial_coherence2 = SpatialCoherence(torch.ones(10, 10, 10, 10), spacing=1, wavelength=1)
+
+        with self.assertRaises(TypeError):
+            spatial_coherence1.inner(spatial_coherence2)
+        with self.assertRaises(TypeError):
+            spatial_coherence1.outer(spatial_coherence2)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -2,7 +2,7 @@ import unittest
 
 import torch
 
-from torchoptics import CoherenceField, Field
+from torchoptics import Field, SpatialCoherence
 from torchoptics.profiles import *
 
 
@@ -370,12 +370,12 @@ class TestGaussianSchellModel(unittest.TestCase):
             spacing=self.spacing,
         )
         field = Field(gaussian_data, spacing=self.spacing, wavelength=self.wavelength)
-        coherence_field = CoherenceField(coherence_data, spacing=self.spacing, wavelength=self.wavelength)
+        spatial_coherence = SpatialCoherence(coherence_data, spacing=self.spacing, wavelength=self.wavelength)
 
-        self.assertTrue(torch.allclose(field.intensity(), coherence_field.intensity()))
+        self.assertTrue(torch.allclose(field.intensity(), spatial_coherence.intensity()))
         self.assertTrue(
             torch.allclose(
-                field.propagate_to_z(0.2).intensity(), coherence_field.propagate_to_z(0.2).intensity()
+                field.propagate_to_z(0.2).intensity(), spatial_coherence.propagate_to_z(0.2).intensity()
             )
         )
         self.assertEqual(coherence_data.dtype, torch.double)

--- a/torchoptics/__init__.py
+++ b/torchoptics/__init__.py
@@ -9,7 +9,7 @@ from torchoptics.config import (
     set_default_spacing,
     set_default_wavelength,
 )
-from torchoptics.fields import CoherenceField, Field
+from torchoptics.fields import Field, SpatialCoherence
 from torchoptics.optics_module import OpticsModule
 from torchoptics.planar_geometry import PlanarGeometry
 from torchoptics.system import System

--- a/torchoptics/__init__.py
+++ b/torchoptics/__init__.py
@@ -1,4 +1,4 @@
-"""TorchOptics is an open-source Python library for differentiable wave optics simulations with PyTorch."""
+"""TorchOptics: Differentiable wave optics simulations with PyTorch."""
 
 import torchoptics.elements
 import torchoptics.functional

--- a/torchoptics/__init__.py
+++ b/torchoptics/__init__.py
@@ -9,7 +9,7 @@ from torchoptics.config import (
     set_default_spacing,
     set_default_wavelength,
 )
-from torchoptics.fields import CoherenceField, Field, PolarizedField
+from torchoptics.fields import CoherenceField, Field
 from torchoptics.optics_module import OpticsModule
 from torchoptics.planar_geometry import PlanarGeometry
 from torchoptics.system import System

--- a/torchoptics/elements/__init__.py
+++ b/torchoptics/elements/__init__.py
@@ -1,7 +1,7 @@
 """This module contains the classes for the optical elements."""
 
 from .beam_splitters import BeamSplitter, PolarizingBeamSplitter
-from .detectors import Detector, FieldDetector, IntensityDetector
+from .detectors import Detector, LinearDetector
 from .elements import Element, ModulationElement, PolarizedModulationElement, PolychromaticModulationElement
 from .identity_element import IdentityElement
 from .lens import Lens

--- a/torchoptics/elements/beam_splitters.py
+++ b/torchoptics/elements/beam_splitters.py
@@ -5,7 +5,7 @@ from typing import Optional
 import torch
 from torch import Tensor
 
-from ..fields import Field, PolarizedField
+from ..fields import Field
 from ..type_defs import Scalar, Vector2
 from ..utils import copy
 from .elements import Element
@@ -107,17 +107,15 @@ class PolarizingBeamSplitter(Element):
     The polarizing beam splitter splits the input field into two orthogonal polarizations.
     """
 
-    def forward(self, field: PolarizedField) -> tuple[PolarizedField, PolarizedField]:
+    def forward(self, field: Field) -> tuple[Field, Field]:
         """
         Applies the beam splitter to the input field.
 
         Args:
-            field (PolarizedField): The field to split.
+            field (Field): The field to split.
 
         Returns:
-            tuple[PolarizedField, PolarizedField]: The split fields.
+            tuple[Field, Field]: The split fields.
         """
         self.validate_field(field)
-        if not torch.all(field.data.select(-3, 2) == 0):
-            raise ValueError("Polarized field cannot have z polarization.")
         return field.polarized_split()[:2]

--- a/torchoptics/elements/detectors.py
+++ b/torchoptics/elements/detectors.py
@@ -7,7 +7,7 @@ from torch.nn.functional import linear
 
 from ..fields import Field
 from ..type_defs import Scalar, Vector2
-from ..utils import validate_tensor_dim
+from ..utils import validate_tensor_ndim
 from .elements import Element
 
 __all__ = ["Detector", "LinearDetector"]
@@ -90,7 +90,7 @@ class LinearDetector(Element):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        validate_tensor_dim(weight, "weight", 3)
+        validate_tensor_ndim(weight, "weight", 3)
         super().__init__(weight.shape[1:], z, spacing, offset)
         self.register_optics_property("weight", weight)
 

--- a/torchoptics/elements/detectors.py
+++ b/torchoptics/elements/detectors.py
@@ -10,7 +10,7 @@ from ..type_defs import Scalar, Vector2
 from ..utils import validate_tensor_dim
 from .elements import Element
 
-__all__ = ["Detector", "IntensityDetector", "FieldDetector"]
+__all__ = ["Detector", "LinearDetector"]
 
 
 class Detector(Element):
@@ -49,11 +49,14 @@ class Detector(Element):
         return field.intensity() * self.cell_area()
 
 
-class IntensityDetector(Element):
+class LinearDetector(Element):
     r"""
-    Intensity detector element.
+    Linear detector element, conceptually similar to :class:`torch.nn.Linear`.
 
-    Computes the total weighted power measured by the detector using the following equation:
+    Applies a spatially varying weight to the field intensity and integrates over the plane,
+    producing a weighted sum for each output channel.
+
+    The total weighted power measured by the detector is computed as:
 
     .. math::
         P_c = \sum_{i, j} w_{c, i, j} \cdot I_{i, j} \cdot \Delta A_{\text{cell}}
@@ -78,7 +81,6 @@ class IntensityDetector(Element):
         offset (Optional[Vector2]): Center coordinates of the plane. Default: `(0, 0)`.
     """
 
-    _weight_is_complex = False
     weight: Tensor
 
     def __init__(
@@ -90,7 +92,7 @@ class IntensityDetector(Element):
     ) -> None:
         validate_tensor_dim(weight, "weight", 3)
         super().__init__(weight.shape[1:], z, spacing, offset)
-        self.register_optics_property("weight", weight, is_complex=self._weight_is_complex)
+        self.register_optics_property("weight", weight)
 
     def forward(self, field: Field) -> Tensor:
         """
@@ -117,52 +119,3 @@ class IntensityDetector(Element):
         """
         kwargs.update({"symbol": r"$\mathcal{W}_{" + str(index[-1]) + r"}$"})
         return self._visualize(self.weight, index, **kwargs)
-
-
-class FieldDetector(IntensityDetector):
-    r"""
-    Field detector element.
-
-    Computes the total weighted power from field data using the inner product of the field with a weight
-    tensor, based on the following equation:
-
-    .. math::
-        P_c = \left| \sum_{i, j} w_{c, i, j} \cdot \psi_{i, j} \cdot \Delta A_{\text{cell}} \right|^2
-
-    where:
-        - :math:`P_c` is the total weighted power measured by the detector for channel :math:`c`,
-        - :math:`w_{c, i, j}` is the weight matrix for channel :math:`c`,
-        - :math:`\psi_{i, j}` is the field at position :math:`(i, j)`, and
-        - :math:`\Delta A_{\text{cell}}` is the area of a single grid cell.
-
-    .. note::
-        This equation in its integral form is expressed as:
-
-        .. math::
-            P_c = \left| \int \int w_c(x, y) \cdot \psi(x, y) \, dx \, dy \right|^2
-
-    Args:
-        weight (Tensor): Weight matrix of shape (C, H, W).
-        z (Scalar): Position along the z-axis. Default: `0`.
-        spacing (Optional[Vector2]): Distance between grid points along planar dimensions. Default: if
-            `None`, uses a global default (see :meth:`torchoptics.set_default_spacing()`).
-        offset (Optional[Vector2]): Center coordinates of the plane. Default: `(0, 0)`.
-
-    """
-
-    _weight_is_complex = True
-
-    def forward(self, field: Field) -> Tensor:
-        """
-        Calculates the weighted power from the field using the inner product with the weight matrix.
-
-        Args:
-            field (Field): The input field.
-
-        Returns:
-            Tensor: The weighted power after applying the inner product and calculating the magnitude squared.
-        """
-        self.validate_field(field)
-        data_flat, weight_flat = field.data.flatten(-2), self.weight.flatten(-2)
-        inner_prod = linear(data_flat, weight_flat) * self.cell_area()  # pylint: disable=not-callable
-        return inner_prod.abs().square()

--- a/torchoptics/elements/elements.py
+++ b/torchoptics/elements/elements.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 from torch import Tensor
 
-from ..fields import Field, PolarizedField
+from ..fields import Field
 from ..planar_geometry import PlanarGeometry
 from ..type_defs import Scalar
 
@@ -140,15 +140,15 @@ class PolarizedModulationElement(Element):
         offset (Optional[Vector2]): Center coordinates of the plane. Default: `(0, 0)`.
     """
 
-    def forward(self, field: PolarizedField) -> PolarizedField:
+    def forward(self, field: Field) -> Field:
         """
         Modulates the polarized field.
 
         Args:
-            field (PolarizedField): The field to modulate.
+            field (Field): The field to modulate.
 
         Returns:
-            PolarizedField: The modulated polarized field."""
+            Field: The modulated polarized field."""
         self.validate_field(field)
         return field.polarized_modulate(self.polarized_modulation_profile())
 

--- a/torchoptics/elements/modulators.py
+++ b/torchoptics/elements/modulators.py
@@ -7,7 +7,7 @@ from torch import Tensor
 
 from ..config import wavelength_or_default
 from ..type_defs import Scalar, Vector2
-from ..utils import validate_tensor_dim
+from ..utils import validate_tensor_ndim
 from .elements import ModulationElement, PolychromaticModulationElement
 
 __all__ = ["Modulator", "PhaseModulator", "AmplitudeModulator", "PolychromaticPhaseModulator"]
@@ -36,7 +36,7 @@ class Modulator(ModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        validate_tensor_dim(modulation, "modulation", 2)
+        validate_tensor_ndim(modulation, "modulation", 2)
         super().__init__(modulation.shape, z, spacing, offset)
         self.register_optics_property("modulation", modulation, is_complex=True)
 
@@ -67,7 +67,7 @@ class PhaseModulator(ModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        validate_tensor_dim(phase, "phase", 2)
+        validate_tensor_ndim(phase, "phase", 2)
         super().__init__(phase.shape, z, spacing, offset)
         self.register_optics_property("phase", phase)
 
@@ -98,7 +98,7 @@ class AmplitudeModulator(ModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        validate_tensor_dim(amplitude, "amplitude", 2)
+        validate_tensor_ndim(amplitude, "amplitude", 2)
         super().__init__(amplitude.shape, z, spacing, offset)
         self.register_optics_property("amplitude", amplitude)
 
@@ -139,7 +139,7 @@ class PolychromaticPhaseModulator(PolychromaticModulationElement):
         spacing: Optional[Vector2] = None,
         offset: Optional[Vector2] = None,
     ) -> None:
-        validate_tensor_dim(optical_path_length, "optical_path_length", 2)
+        validate_tensor_ndim(optical_path_length, "optical_path_length", 2)
         super().__init__(optical_path_length.shape, z, spacing, offset)
         self.register_optics_property("optical_path_length", optical_path_length)
 

--- a/torchoptics/elements/polarized_modulators.py
+++ b/torchoptics/elements/polarized_modulators.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor
 
 from ..type_defs import Scalar, Vector2
-from ..utils import validate_tensor_dim
+from ..utils import validate_tensor_ndim
 from .elements import PolarizedModulationElement
 
 __all__ = ["PolarizedModulator", "PolarizedPhaseModulator", "PolarizedAmplitudeModulator"]
@@ -106,7 +106,7 @@ class PolarizedAmplitudeModulator(PolarizedModulationElement):
 
 
 def _validate_tensor(tensor, name):
-    validate_tensor_dim(tensor, name, 4)
+    validate_tensor_ndim(tensor, name, 4)
     if tensor.shape[:2] != (3, 3):
         raise ValueError(
             f"Expected first two dimensions of {name} to have shape (3, 3), but got {tensor.shape[:2]}"

--- a/torchoptics/fields.py
+++ b/torchoptics/fields.py
@@ -19,7 +19,7 @@ __all__ = ["Field", "CoherenceField"]
 
 class Field(PlanarGeometry):  # pylint: disable=abstract-method
     """
-    Scalar optical field.
+    Optical field class.
 
     Args:
         data (Tensor): The complex-valued field data.
@@ -170,7 +170,7 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
         modulated_data = (self.data.unsqueeze(self._polarization_dim - 1) * polarized_modulation_profile).sum(
             self._polarization_dim
         )
-        return copy(self, data=modulated_data)  # type: ignore[return-value]
+        return copy(self, data=modulated_data)
 
     def polarized_split(self) -> tuple[Field, Field, Field]:
         """
@@ -185,7 +185,7 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
             fields[i].data.select(self._polarization_dim, i).copy_(
                 self.data.select(self._polarization_dim, i)
             )
-        return fields  # type: ignore[return-value]
+        return fields
 
     def normalize(self, normalized_power: Scalar = 1.0) -> Field:
         """
@@ -268,7 +268,7 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
 
 class CoherenceField(Field):  # pylint: disable=abstract-method
     """
-    Scalar optical spatial coherence.
+    Spatial Coherence Field class.
 
     Args:
         data (Tensor): The complex-valued spatial coherence data.

--- a/torchoptics/fields.py
+++ b/torchoptics/fields.py
@@ -1,4 +1,4 @@
-"""This module defines the Field and CoherenceField classes."""
+"""This module defines the Field and SpatialCoherence classes."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from .propagation import propagator
 from .type_defs import Scalar, Vector2
 from .utils import copy
 
-__all__ = ["Field", "CoherenceField"]
+__all__ = ["Field", "SpatialCoherence"]
 
 
 class Field(PlanarGeometry):  # pylint: disable=abstract-method
@@ -266,9 +266,9 @@ class Field(PlanarGeometry):  # pylint: disable=abstract-method
             )
 
 
-class CoherenceField(Field):  # pylint: disable=abstract-method
+class SpatialCoherence(Field):  # pylint: disable=abstract-method
     """
-    Spatial Coherence Field class.
+    Spatial Coherence class.
 
     Args:
         data (Tensor): The complex-valued spatial coherence data.
@@ -305,12 +305,12 @@ class CoherenceField(Field):  # pylint: disable=abstract-method
         return copy(self, data=normalized_data)
 
     def inner(self, other: Field) -> Tensor:
-        """CoherenceField does not support the inner product."""
-        raise TypeError("inner() is not applicable for CoherenceField.")
+        """SpatialCoherence does not support the inner product."""
+        raise TypeError("inner() is not applicable for SpatialCoherence.")
 
     def outer(self, other: Field) -> Tensor:
-        """CoherenceField does not support the outer product."""
-        raise TypeError("outer() is not applicable for CoherenceField.")
+        """SpatialCoherence does not support the outer product."""
+        raise TypeError("outer() is not applicable for SpatialCoherence.")
 
     def visualize(self, *index: int, **kwargs) -> Any:
         """

--- a/torchoptics/fields.py
+++ b/torchoptics/fields.py
@@ -304,6 +304,14 @@ class CoherenceField(Field):  # pylint: disable=abstract-method
         normalized_data = self.data * ratio
         return copy(self, data=normalized_data)
 
+    def inner(self, other: Field) -> Tensor:
+        """CoherenceField does not support the inner product."""
+        raise TypeError("inner() is not applicable for CoherenceField.")
+
+    def outer(self, other: Field) -> Tensor:
+        """CoherenceField does not support the outer product."""
+        raise TypeError("outer() is not applicable for CoherenceField.")
+
     def visualize(self, *index: int, **kwargs) -> Any:
         """
         Visualizes the the time-averaged intensity (diagonal of the spatial coherence matrix).

--- a/torchoptics/functional/functional.py
+++ b/torchoptics/functional/functional.py
@@ -92,7 +92,7 @@ def fftfreq_grad(n: int, d: Tensor) -> Tensor:
 
 def get_coherence_evolution(evolution_func):
     r"""
-    Decorator that constructs the evolution function for a coherence field given an evolution operator
+    Decorator that constructs the evolution function for spatial coherence given an evolution operator
     :math:`U`.
 
     The input function applies the evolution :math:`U` to a :class:`~torchoptics.fields.Field` instance:
@@ -100,7 +100,7 @@ def get_coherence_evolution(evolution_func):
     .. math::
         \psi \to U \psi
 
-    while the returned function extends this transformation to a :class:`~torchoptics.fields.CoherenceField`
+    while the returned function extends this transformation to a :class:`~torchoptics.fields.SpatialCoherence`
     instance:
 
     .. math::

--- a/torchoptics/utils.py
+++ b/torchoptics/utils.py
@@ -64,9 +64,9 @@ def initialize_tensor(
     return tensor
 
 
-def validate_tensor_dim(tensor: Tensor, name: str, dim: int) -> None:
+def validate_tensor_ndim(tensor: Tensor, name: str, ndim: int) -> None:
     """
-    Validates that a PyTorch tensor has the expected shape.
+    Validates that a PyTorch tensor has the expected number of dimensions.
 
     Args:
         tensor (Tensor): The PyTorch tensor to validate.
@@ -76,8 +76,28 @@ def validate_tensor_dim(tensor: Tensor, name: str, dim: int) -> None:
     """
     if not isinstance(tensor, Tensor):
         raise TypeError(f"Expected '{name}' to be a Tensor, but got {type(tensor).__name__}")
-    if tensor.dim() != dim:
-        raise ValueError(f"Expected '{name}' to be a {dim}D tensor, but got {tensor.dim()}D")
+    if tensor.ndim != ndim:
+        raise ValueError(f"Expected '{name}' to be a {ndim}D tensor, but got {tensor.ndim}D")
+
+
+def validate_tensor_min_ndim(tensor: Tensor, name: str, min_ndim: int) -> None:
+    """
+    Validates that a PyTorch tensor has at least a minimum number of dimensions.
+
+    Args:
+        tensor (Tensor): The PyTorch tensor to validate.
+        name (str): The name of the tensor, used in error messages.
+        min_ndim (int): The minimum number of dimensions required.
+
+    Raises:
+        TypeError: If the input is not a Tensor.
+        ValueError: If the tensor does not meet the minimum dimension requirement.
+    """
+    if not isinstance(tensor, Tensor):
+        raise TypeError(f"Expected '{name}' to be a Tensor, but got {type(tensor).__name__}.")
+
+    if tensor.ndim < min_ndim:
+        raise ValueError(f"Expected '{name}' to have at least {min_ndim} dimensions, but got {tensor.ndim}.")
 
 
 def copy(obj, **kwargs):

--- a/torchoptics/visualization.py
+++ b/torchoptics/visualization.py
@@ -41,7 +41,7 @@ def visualize_tensor(
         return_fig (bool, optional): Whether to return the figure. Default: `False`.
     """
 
-    if tensor.dim() < 2 or not all(s == 1 for s in tensor.shape[:-2]):  # Check if squeezed tensor is 2D
+    if tensor.ndim < 2 or not all(s == 1 for s in tensor.shape[:-2]):  # Check if squeezed tensor is 2D
         raise ValueError(f"Expected tensor to be 2D, but got shape {tensor.shape}.")
     tensor = tensor.detach().cpu().view(tensor.shape[-2], tensor.shape[-1])
 


### PR DESCRIPTION
- Rename `CoherenceField` to `SpatialCoherence`
- Remove `PolarizedField` class. Instead, polarization can be simulated directly with the `Field` and `SpatialCoherence` classes using `polarized_modulate()`. 
- Remove `FieldDetector` class. Instead, use  `inner()` method to perform the operation. 
- Rename `IntensityDetector` to `LinearDetector`
- Add `get_coherence_evolution()` to return a the spatial coherence evolution function 
- Refactor validation methods in `Field`
- Add test