### PR TITLE
Refactor `elements` in `System` to `tuple` for better type safety and type hinting

### DIFF
--- a/tests/elements/test_element.py
+++ b/tests/elements/test_element.py
@@ -15,3 +15,12 @@ def test_element():
     field = Field(torch.ones(3, *shape), wavelength=700e-9, spacing=spacing, z=2)
     with pytest.raises(ValueError):
         element.validate_field(field)
+
+
+def test_visualize_raises_error():
+    shape = (32, 32)
+    z = 0
+    spacing = 1
+    element = Element(shape, z, spacing=spacing)
+    with pytest.raises(NotImplementedError):
+        element.visualize()

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -89,9 +89,8 @@ def test_elements_along_field_path():
     system2 = System()
     with pytest.raises(ValueError):
         system2(input_field)
-    system3 = System(PlanarGrid(shape, z=0, spacing=spacing))
     with pytest.raises(TypeError):
-        system3(input_field)
+        System(PlanarGrid(shape, z=0, spacing=spacing))
 
 
 def test_dunder_methods():

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -86,11 +86,8 @@ def test_elements_along_field_path():
         system1.measure_at_z(input_field, 4 * propagation_distance)
     with pytest.raises(ValueError):
         system1.measure_at_z(input_field, -1)
-    system2 = System()
-    with pytest.raises(ValueError):
-        system2(input_field)
     with pytest.raises(TypeError):
-        System(PlanarGrid(shape, z=0, spacing=spacing))
+        System(PlanarGrid(shape, z=0, spacing=spacing))  # Should be type Element
 
 
 def test_dunder_methods():
@@ -133,3 +130,11 @@ def test_identity_element():
     elements_in_path = system.elements_in_field_path(input_field, output_element)
     assert len(elements_in_path) == 1
     assert elements_in_path[0] is output_element
+
+
+def test_last_element():
+    shape, spacing, _, propagation_distance, _, _, _, _, _, input_field, _ = make_system_setup()
+    system = System()
+    plane = PlanarGrid(shape, z=2 * propagation_distance, spacing=spacing)
+    with pytest.raises(TypeError):
+        system.elements_in_field_path(input_field, plane)

--- a/torchoptics/elements/beam_splitters.py
+++ b/torchoptics/elements/beam_splitters.py
@@ -13,7 +13,7 @@ from .elements import Element
 __all__ = ["BeamSplitter", "PolarizingBeamSplitter"]
 
 
-class BeamSplitter(Element):
+class BeamSplitter(Element):  # pylint: disable=W0223
     r"""
     Beam splitter element.
 
@@ -100,7 +100,7 @@ class BeamSplitter(Element):
         return copy(field, data=output_data0), copy(field, data=output_data1)
 
 
-class PolarizingBeamSplitter(Element):
+class PolarizingBeamSplitter(Element):  # pylint: disable=W0223
     """
     Polarizing beam splitter element.
 

--- a/torchoptics/elements/detectors.py
+++ b/torchoptics/elements/detectors.py
@@ -13,7 +13,7 @@ from .elements import Element
 __all__ = ["Detector", "LinearDetector"]
 
 
-class Detector(Element):
+class Detector(Element):  # pylint: disable=W0223
     r"""
     Detector element.
 

--- a/torchoptics/elements/elements.py
+++ b/torchoptics/elements/elements.py
@@ -43,6 +43,10 @@ class Element(PlanarGrid):  # pylint: disable=abstract-method
                 f"\nElement geometry: {self.geometry_str()}"
             )
 
+    def visualize(self, **kwargs) -> Any:
+        """Visualize the Element."""
+        raise NotImplementedError(f"Visualization is not implemented for {self.__class__.__name__}.")
+
 
 class ModulationElement(Element, ABC):
     """

--- a/torchoptics/elements/elements.py
+++ b/torchoptics/elements/elements.py
@@ -12,7 +12,7 @@ from ..type_defs import Scalar
 __all__ = ["Element", "ModulationElement", "PolarizedModulationElement"]
 
 
-class Element(PlanarGrid):  # pylint: disable=abstract-method
+class Element(PlanarGrid):
     """
     Base class for optical elements.
 

--- a/torchoptics/elements/identity_element.py
+++ b/torchoptics/elements/identity_element.py
@@ -6,7 +6,7 @@ from .elements import Element
 __all__ = ["IdentityElement"]
 
 
-class IdentityElement(Element):
+class IdentityElement(Element):  # pylint: disable=W0223
     """
     Identity element.
 

--- a/torchoptics/system.py
+++ b/torchoptics/system.py
@@ -2,14 +2,12 @@
 
 from typing import Optional
 
-from torch.nn import Module, ModuleList
+from torch.nn import Module
 
 from .elements import Element, IdentityElement
 from .fields import Field
 from .planar_grid import PlanarGrid
 from .type_defs import Scalar, Vector2
-
-__all__ = ["System"]
 
 
 class System(Module):
@@ -55,16 +53,25 @@ class System(Module):
 
     def __init__(self, *elements: Element) -> None:
         super().__init__()
-        self.elements = ModuleList(elements)
+        for i, element in enumerate(elements):
+            if not isinstance(element, Element):
+                raise TypeError(f"Expected element {i} to be an Element, but got {type(element).__name__}.")
+            self.add_module(str(i), element)
+        self._elements = tuple(elements)
 
     def __iter__(self):
         return iter(self.elements)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> Element:
         return self.elements[index]
 
     def __len__(self):
         return len(self.elements)
+
+    @property
+    def elements(self) -> tuple[Element, ...]:
+        """Returns the elements in the system."""
+        return self._elements
 
     def forward(self, field: Field, **prop_kwargs) -> Field:
         """

--- a/torchoptics/system.py
+++ b/torchoptics/system.py
@@ -176,6 +176,10 @@ class System(Module):
         elements_in_path = [element for element in self.sorted_elements() if field.z <= element.z]
 
         if last_element:
+            if not isinstance(last_element, Element):
+                raise TypeError(
+                    f"Expected last_element to be an Element, but got {type(last_element).__name__}."
+                )
             if last_element.z < field.z:
                 raise ValueError(f"Field z ({field.z}) is greater than last element z ({last_element.z}).")
 
@@ -186,11 +190,6 @@ class System(Module):
                 elements_in_path.pop()
 
             elements_in_path.append(last_element)
-
-        if not elements_in_path:
-            raise ValueError("No elements found in the field path.")
-        if not all(isinstance(element, Element) for element in elements_in_path):
-            raise TypeError("All elements in the field path must be instances of Element.")
 
         return tuple(elements_in_path)
 


### PR DESCRIPTION
- Changed `elements` in `System` from `ModuleList` to a `tuple`  to enable static type checking and ensure all are `Element` instances.
- Added `visualize()` to the `Element` base class to improve type hints in subclasses.