### PR TITLE
Update slicing support in `System` 

### DIFF
--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -138,3 +138,33 @@ def test_last_element():
     plane = PlanarGrid(shape, z=2 * propagation_distance, spacing=spacing)
     with pytest.raises(TypeError):
         system.elements_in_field_path(input_field, plane)  # type: ignore
+
+
+def test_slicing():
+    (
+        shape,
+        _,
+        _,
+        propagation_distance,
+        modulator1_spacing,
+        modulator1_offset,
+        modulator2_spacing,
+        modulator2_offset,
+        _,
+        _,
+        mod_profile,
+    ) = make_system_setup()
+    modulator1 = Modulator(mod_profile, propagation_distance, modulator1_spacing, modulator1_offset)
+    modulator2 = Modulator(mod_profile, 2 * propagation_distance, modulator2_spacing, modulator2_offset)
+    detector = Detector(shape, z=2 * propagation_distance, spacing=modulator1_spacing)
+    system = System(modulator1, modulator2, detector)
+
+    assert system[0] is modulator1
+    assert system[1] is modulator2
+    assert system[2] is detector
+
+    system_slice = system[:2]
+    assert isinstance(system_slice, System)
+    assert len(system_slice) == 2
+    assert system_slice[0] is modulator1
+    assert system_slice[1] is modulator2

--- a/torchoptics/system.py
+++ b/torchoptics/system.py
@@ -62,7 +62,8 @@ class System(Module):
     def __iter__(self):
         return iter(self.elements)
 
-    def __getitem__(self, index) -> Element:
+    def __getitem__(self, index):
+        # TODO: Return system when index is a slice
         return self.elements[index]
 
     def __len__(self):

--- a/torchoptics/system.py
+++ b/torchoptics/system.py
@@ -1,6 +1,6 @@
 """This module defines the System class."""
 
-from typing import Optional
+from typing import Iterator, Optional, Union, overload
 
 from torch.nn import Module
 
@@ -12,40 +12,29 @@ from .type_defs import Scalar, Vector2
 
 class System(Module):
     """
-    System of optical elements similar to the :class:`torch.nn.Sequential` module.
+    Optical system of elements similar to :class:`torch.nn.Sequential`.
 
-    The system is defined by a sequence of optical elements which are sorted by their ``z`` position.
-    The :meth:`forward()` method accepts a :class:`Field` object as input. The field is
-    propagated to the first element in the system which processes it using its ``forward()`` method.
-    The field is then propagated to the next element in the system and so on, finally returning the
-    field after it has been processed by the last element in the system.
+    The system consists of a sequence of optical elements, ordered by their ``z`` positions.
+    When a :class:`~torchoptics.Field` is passed to :meth:`forward`, it is propagated through the system:
+    each element applies its own transformation via :meth:`~torchoptics.elements.Element.forward`.
+    The output from the final element is returned.
+
+    Field measurements at arbitrary planes can be performed using :meth:`measure`, :meth:`measure_at_z`, or
+    :meth:`measure_at_plane`.
+
+    Indexing with ``system[i]`` returns the i-th optical element. Slicing, e.g. ``system[i:j]``,
+    returns a new :class:`System` containing the selected elements.
 
     Example:
-        Initialize a 4f optical system with two lenses::
+        Create a 4f system consisting of two lenses::
 
-            import torch
-            import torchoptics
-            from torchoptics import Field, System
-            from torchoptics.elements import Lens
-
-            # Set simulation properties
-            shape = 1000  # Number of grid points in each dimension
-            spacing = 10e-6  # Spacing between grid points (m)
-            wavelength = 700e-9  # Field wavelength (m)
-            focal_length = 200e-3  # Lens focal length (m)
-
-            # Determine device
-            device = "cuda" if torch.cuda.is_available() else "cpu"
-
-            # Configure torchoptics default properties
-            torchoptics.set_default_spacing(spacing)
-            torchoptics.set_default_wavelength(wavelength)
-
-            # Define 4f optical system with two lenses
             system = System(
                 Lens(shape, focal_length, z=1 * focal_length),
                 Lens(shape, focal_length, z=3 * focal_length),
             ).to(device)
+
+            # Measure the field at the 4f plane
+            output_field = system.measure_at_z(input_field, z=4 * focal_length)
 
     Args:
         *elements (Element): Optical elements in the system.
@@ -59,14 +48,21 @@ class System(Module):
             self.add_module(str(i), element)
         self._elements = tuple(elements)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Element]:
         return iter(self.elements)
 
-    def __getitem__(self, index):
-        # TODO: Return system when index is a slice
+    @overload
+    def __getitem__(self, index: int) -> Element: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> "System": ...
+
+    def __getitem__(self, index: Union[int, slice]) -> Union[Element, "System"]:
+        if isinstance(index, slice):
+            return self.__class__(*self.elements[index])
         return self.elements[index]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.elements)
 
     @property


### PR DESCRIPTION
- Update slicing behavior in `System` to match `torch.nn.Sequential`, returning a new `System` instance instead of a list of `Element`s.
- Improve `System` docstring and dunder method type hints.